### PR TITLE
Add nix flake + direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ public-client/
 server.json
 .env
 
+# Nix
+result
+.direnv/
+
 # Bot folders (except template)
 bots/*/
 !bots/_template/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770169770,
+        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "rs-sdk dev shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            bun
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Summary
- Add `flake.nix` dev shell providing `bun` for a reproducible dev environment
- Add `.envrc` (`use flake`) for automatic shell activation via direnv
- Update `.gitignore` to ignore `result/` and `.direnv/`

## Usage
```
cd rs-sdk     # direnv auto-activates
bun install   # just works
```

Or manually: `nix develop`

## Test plan
- [ ] `nix develop --ignore-environment` — verify `bun` is available and `bun install` succeeds
- [ ] `direnv allow` — verify shell activates on `cd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)