### PR TITLE
Add player-to-player trade API

### DIFF
--- a/mcp/api/bot.ts
+++ b/mcp/api/bot.ts
@@ -56,6 +56,14 @@
  * - depositAll() - Deposit entire inventory
  * - withdrawItem(item, amount?) - Withdraw item from bank
  *
+ * == Trading ==
+ * - requestTrade(target, timeout?) - Request trade with nearby player (walks if needed)
+ * - offerItem(target, amount?) - Offer item from inventory in trade window
+ * - removeOffer(target, amount?) - Remove item from your trade offer
+ * - acceptTrade(timeout?) - Accept trade (first screen, clicks accept button)
+ * - confirmTrade(timeout?) - Confirm trade (second screen, finalizes trade)
+ * - declineTrade() - Decline/close trade window
+ *
  * == Crafting ==
  * - smithAtAnvil(product, options?) - Smith bars at anvil
  * - fletchLogs(product?) - Fletch logs into bows/arrows

--- a/mcp/api/sdk.ts
+++ b/mcp/api/sdk.ts
@@ -17,7 +17,7 @@
  * - getConnectionState() - Get connection state ('connected', 'connecting', 'disconnected', 'reconnecting')
  *
  * == State Access (Synchronous) ==
- * - getState(): BotWorldState - Full state snapshot. Shape: { tick, inGame, player: PlayerState | null, skills: SkillState[], inventory: InventoryItem[], equipment: InventoryItem[], nearbyNpcs: NearbyNpc[], nearbyPlayers: NearbyPlayer[], nearbyLocs: NearbyLoc[], groundItems: GroundItem[], gameMessages: GameMessage[], dialog: DialogState, shop: ShopState, bank: BankState, combatEvents: CombatEvent[] }
+ * - getState(): BotWorldState - Full state snapshot. Shape: { tick, inGame, player: PlayerState | null, skills: SkillState[], inventory: InventoryItem[], equipment: InventoryItem[], nearbyNpcs: NearbyNpc[], nearbyPlayers: NearbyPlayer[], nearbyLocs: NearbyLoc[], groundItems: GroundItem[], gameMessages: GameMessage[], dialog: DialogState, shop: ShopState, bank: BankState, trade: TradeState, combatEvents: CombatEvent[] }
  * - getStateAge(): number - Milliseconds since last state update
  *
  * == State Queries (all return directly, NOT wrapped in objects) ==
@@ -29,9 +29,22 @@
  * - findNearbyLoc(pattern): NearbyLoc | undefined - Find location by name/regex
  * - getGroundItems(): GroundItem[] - Returns array directly. Each: { id, name, count, x, z, distance }
  * - findGroundItem(pattern): GroundItem | undefined - Find ground item by name/regex
+ * - getNearbyPlayer(index): NearbyPlayer | null - Get player by index
+ * - findNearbyPlayer(pattern): NearbyPlayer | null - Find player by name/regex
+ * - getNearbyPlayers(): NearbyPlayer[] - All nearby players
  * - getSkill(name): SkillState | undefined - Returns { name, level, baseLevel, experience }
  * - getAllSkills(): SkillState[] - All skills
  * - getEquippedItems(): InventoryItem[] - Worn equipment as array
+ *
+ * == Trade State Queries ==
+ * - isTradeOpen(): boolean - Check if trade window is open
+ * - isTradeConfirmOpen(): boolean - Check if trade confirm screen is open
+ * - getTradePartnerName(): string - Get trade partner's name
+ * - getTradeStatusText(): string - Get trade status text
+ * - getTradeMyOffer(): TradeItem[] - Items in your trade offer
+ * - getTradeTheirOffer(): TradeItem[] - Items in partner's trade offer
+ * - getTradeMyInventory(): TradeItem[] - Your inventory items in trade side panel
+ * - findTradeItem(pattern, items): TradeItem | null - Find item in trade item list
  *
  * == Key Types ==
  * PlayerState: { name, combatLevel, x, z, worldX, worldZ, level (floor 0-3), runEnergy, animId, combat: { inCombat, targetIndex, lastDamageTick } }
@@ -53,6 +66,11 @@
  * - sendBankWithdraw(bankSlot, amount) - Withdraw item from bank
  * - sendShopBuy(shopSlot, amount) - Buy from shop
  * - sendShopSell(invSlot, amount) - Sell to shop
+ * - sendTradeOffer(slot, amount) - Offer item in trade (1/5/10/-1 for all/custom)
+ * - sendTradeRemove(slot, amount) - Remove item from trade offer
+ * - sendClickComponent(3420) - Accept trade (first screen)
+ * - sendClickComponent(3546) - Confirm trade (second screen)
+ * - sendCloseModal() - Decline/close trade
  * - sendCastSpell(spellName) - Cast spell
  * - sendCastSpellOnNpc(spellName, npcIndex) - Cast spell on NPC
  * - sendCastSpellOnItem(spellName, slot) - Cast spell on item

--- a/sdk/API.md
+++ b/sdk/API.md
@@ -75,6 +75,17 @@ These methods wait for the **effect to complete**, not just server acknowledgmen
 | `depositItem(target, amount)` | Deposit an item into the bank. |
 | `withdrawItem(target, amount)` | Withdraw an item from the bank by slot number. |
 
+### Trading
+
+| Method | Description |
+|--------|-------------|
+| `requestTrade(target, timeout)` | Request a trade with a nearby player. Walks to them if needed. |
+| `offerItem(target, amount)` | Offer an item from your inventory in the trade window. |
+| `removeOffer(target, amount)` | Remove an item from your trade offer. |
+| `acceptTrade(timeout)` | Accept the trade (first screen). |
+| `confirmTrade(timeout)` | Confirm the trade (second/confirmation screen). |
+| `declineTrade()` | Decline the current trade by closing the modal. |
+
 ### Crafting & Smithing
 
 | Method | Description |
@@ -133,6 +144,17 @@ These methods resolve when server **acknowledges** them (not when effects comple
 | `getNearbyLoc(x, z, id)` | Get location (object) by coordinates and ID. |
 | `findNearbyLoc(pattern)` | Find location by name pattern. |
 | `findGroundItem(pattern)` | Find ground item by name pattern. |
+| `getNearbyPlayer(index)` | Get a nearby player by index. |
+| `findNearbyPlayer(pattern)` | Find a nearby player by name pattern. |
+| `getNearbyPlayers()` | Get all nearby players. |
+| `isTradeOpen()` | Check if trade window is currently open. |
+| `isTradeConfirmOpen()` | Check if trade confirmation screen is open. |
+| `getTradePartnerName()` | Get the trade partner's name. |
+| `getTradeStatusText()` | Get the current trade status text. |
+| `getTradeMyOffer()` | Get items in your trade offer. |
+| `getTradeTheirOffer()` | Get items in the other player's trade offer. |
+| `getTradeMyInventory()` | Get your inventory items shown in the trade side panel. |
+| `findTradeItem(pattern, items)` | Find a trade item by name pattern in a trade item list. |
 
 ### On-Demand Scanning
 
@@ -174,6 +196,8 @@ These methods resolve when server **acknowledges** them (not when effects comple
 | `sendWait(ticks)` | Wait for specified number of game ticks. |
 | `sendBankDeposit(slot, amount)` | Deposit item to bank by slot. |
 | `sendBankWithdraw(slot, amount)` | Withdraw item from bank by slot. |
+| `sendTradeOffer(slot, amount)` | Offer item in trade window (1/5/10/-1 for all/custom). |
+| `sendTradeRemove(slot, amount)` | Remove item from trade offer. |
 | `sendScreenshot(timeout)` | Request a screenshot from the bot client. |
 | `sendFindPath(destX, destZ, maxWaypoints)` | Find path to destination (async alias for findPath). |
 

--- a/sdk/actions-helpers.ts
+++ b/sdk/actions-helpers.ts
@@ -5,9 +5,11 @@ import { BotSDK } from './index';
 import type {
     NearbyLoc,
     NearbyNpc,
+    NearbyPlayer,
     InventoryItem,
     GroundItem,
     ShopItem,
+    TradeItem,
 } from './types';
 
 export class ActionHelpers {
@@ -443,6 +445,24 @@ export class ActionHelpers {
     ): ShopItem | null {
         if (typeof target === 'object' && 'id' in target && 'name' in target) {
             return items.find(i => i.id === target.id) ?? null;
+        }
+        const regex = typeof target === 'string' ? new RegExp(target, 'i') : target;
+        return items.find(i => regex.test(i.name)) ?? null;
+    }
+
+    resolvePlayer(target: NearbyPlayer | string | RegExp): NearbyPlayer | null {
+        if (typeof target === 'object' && 'index' in target) {
+            return target;
+        }
+        return this.sdk.findNearbyPlayer(target);
+    }
+
+    resolveTradeItem(
+        target: TradeItem | string | RegExp,
+        items: TradeItem[]
+    ): TradeItem | null {
+        if (typeof target === 'object' && 'slot' in target && 'id' in target) {
+            return target;
         }
         const regex = typeof target === 'string' ? new RegExp(target, 'i') : target;
         return items.find(i => regex.test(i.name)) ?? null;

--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -12,8 +12,12 @@ import type {
     BankItem,
     NearbyNpc,
     NearbyLoc,
+    NearbyPlayer,
     GroundItem,
     ShopItem,
+    TradeItem,
+    TradeResult,
+    TradeOfferResult,
     ChopTreeResult,
     BurnLogsResult,
     PickupResult,
@@ -3194,6 +3198,215 @@ export class BotActions {
         }
 
         return { success: false, message: 'Stringing amulet timed out', reason: 'timeout' };
+    }
+
+    // ============ Porcelain: Trading ============
+
+    /**
+     * Request a trade with a nearby player.
+     * Walks to them if needed and sends the trade request (OPPLAYER4).
+     * Waits for the trade window to open.
+     */
+    async requestTrade(target: NearbyPlayer | string | RegExp, timeout: number = 15000): Promise<TradeResult> {
+        await this.dismissBlockingUI();
+
+        const player = this.helpers.resolvePlayer(target);
+        if (!player) {
+            return { success: false, message: `Player not found: ${target}`, reason: 'player_not_found' };
+        }
+
+        // Walk closer if needed
+        if (player.distance > 2) {
+            const walkResult = await this.walkTo(player.x, player.z, 2);
+            if (!walkResult.success) {
+                return { success: false, message: `Cannot reach ${player.name}: ${walkResult.message}`, reason: 'cant_reach' };
+            }
+        }
+
+        // Re-find player after walking (they may have moved)
+        const playerNow = this.helpers.resolvePlayer(target);
+        if (!playerNow) {
+            return { success: false, message: `Player ${player.name} no longer nearby`, reason: 'player_not_found' };
+        }
+
+        // Send trade request (option 4 = Trade)
+        const result = await this.sdk.sendInteractPlayer(playerNow.index, 4);
+        if (!result.success) {
+            return { success: false, message: result.message, reason: 'cant_reach' };
+        }
+
+        // Wait for trade window to open
+        try {
+            await this.sdk.waitForCondition(state => {
+                return state.trade?.isOpen === true;
+            }, timeout);
+
+            return { success: true, message: `Trade opened with ${playerNow.name}` };
+        } catch {
+            return { success: false, message: `Trade with ${playerNow.name} did not open (they may not have accepted)`, reason: 'trade_not_opened' };
+        }
+    }
+
+    /**
+     * Offer an item from your inventory in the trade window.
+     * Trade window must already be open.
+     */
+    async offerItem(target: TradeItem | InventoryItem | string | RegExp, amount: number = 1): Promise<TradeOfferResult> {
+        if (!this.sdk.isTradeOpen()) {
+            return { success: false, message: 'Trade window is not open', reason: 'trade_not_open' };
+        }
+
+        const myInventory = this.sdk.getTradeMyInventory();
+        const item = this.helpers.resolveTradeItem(target as any, myInventory);
+        if (!item) {
+            return { success: false, message: `Item not found in trade inventory: ${target}`, reason: 'item_not_found' };
+        }
+
+        const offerBefore = this.sdk.getTradeMyOffer().length;
+
+        await this.sdk.sendTradeOffer(item.slot, amount);
+
+        try {
+            await this.sdk.waitForCondition(state => {
+                // Check if offer changed (new item appeared or count changed)
+                const offerNow = state.trade?.myOffer || [];
+                if (offerNow.length > offerBefore) return true;
+                // Check if the item appeared or count increased in offer
+                const offered = offerNow.find(i => i.id === item.id);
+                return offered !== undefined && offered.count > 0;
+            }, 5000);
+
+            return { success: true, message: `Offered ${item.name} x${amount}` };
+        } catch {
+            return { success: false, message: `Timeout offering ${item.name}`, reason: 'timeout' };
+        }
+    }
+
+    /**
+     * Remove an item from your trade offer.
+     * Trade window must already be open.
+     */
+    async removeOffer(target: TradeItem | string | RegExp, amount: number = 1): Promise<TradeOfferResult> {
+        if (!this.sdk.isTradeOpen()) {
+            return { success: false, message: 'Trade window is not open', reason: 'trade_not_open' };
+        }
+
+        const myOffer = this.sdk.getTradeMyOffer();
+        const item = this.helpers.resolveTradeItem(target, myOffer);
+        if (!item) {
+            return { success: false, message: `Item not found in trade offer: ${target}`, reason: 'item_not_found' };
+        }
+
+        const offerCountBefore = myOffer.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0);
+
+        await this.sdk.sendTradeRemove(item.slot, amount);
+
+        try {
+            await this.sdk.waitForCondition(state => {
+                const offerNow = state.trade?.myOffer || [];
+                const countNow = offerNow.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0);
+                return countNow < offerCountBefore;
+            }, 5000);
+
+            return { success: true, message: `Removed ${item.name} x${amount} from offer` };
+        } catch {
+            return { success: false, message: `Timeout removing ${item.name} from offer`, reason: 'timeout' };
+        }
+    }
+
+    /**
+     * Accept the trade (first screen).
+     * Clicks the accept button and waits for confirm screen or trade close.
+     */
+    async acceptTrade(timeout: number = 10000): Promise<TradeResult> {
+        if (!this.sdk.isTradeOpen()) {
+            return { success: false, message: 'Trade window is not open', reason: 'trade_not_opened' };
+        }
+
+        // Click accept button (component 3420)
+        await this.sdk.sendClickComponent(3420);
+
+        try {
+            await this.sdk.waitForCondition(state => {
+                // Either moved to confirm screen or trade was declined/closed
+                if (state.trade?.isConfirmOpen) return true;
+                if (!state.trade?.isOpen && !state.trade?.isConfirmOpen) return true;
+                return false;
+            }, timeout);
+
+            const state = this.sdk.getState();
+            if (state?.trade?.isConfirmOpen) {
+                return { success: true, message: 'Trade accepted - confirmation screen open' };
+            }
+            if (!state?.trade?.isOpen) {
+                return { success: false, message: 'Trade was declined or closed', reason: 'declined' };
+            }
+
+            return { success: false, message: 'Timeout waiting for trade acceptance', reason: 'timeout' };
+        } catch {
+            return { success: false, message: 'Timeout waiting for trade acceptance', reason: 'timeout' };
+        }
+    }
+
+    /**
+     * Confirm the trade (second/confirmation screen).
+     * Clicks the confirm accept button and waits for trade to close.
+     */
+    async confirmTrade(timeout: number = 10000): Promise<TradeResult> {
+        if (!this.sdk.isTradeConfirmOpen()) {
+            return { success: false, message: 'Trade confirmation screen is not open', reason: 'trade_not_opened' };
+        }
+
+        const msgBaseline = this.helpers.getMessageTick();
+
+        // Click confirm accept button (component 3546)
+        await this.sdk.sendClickComponent(3546);
+
+        try {
+            await this.sdk.waitForCondition(state => {
+                // Trade should close when both players confirm
+                if (!state.trade?.isOpen && !state.trade?.isConfirmOpen) return true;
+                return false;
+            }, timeout);
+
+            // Check for success message
+            const state = this.sdk.getState();
+            if (state) {
+                for (const msg of state.gameMessages) {
+                    if (msg.tick > msgBaseline) {
+                        if (msg.text.toLowerCase().includes('accepted trade')) {
+                            return { success: true, message: 'Trade completed successfully' };
+                        }
+                    }
+                }
+            }
+
+            // Trade closed but no explicit success message - still likely succeeded
+            return { success: true, message: 'Trade completed' };
+        } catch {
+            return { success: false, message: 'Timeout waiting for trade confirmation', reason: 'timeout' };
+        }
+    }
+
+    /**
+     * Decline the current trade by closing the modal.
+     */
+    async declineTrade(): Promise<TradeResult> {
+        if (!this.sdk.isTradeOpen() && !this.sdk.isTradeConfirmOpen()) {
+            return { success: true, message: 'No trade to decline' };
+        }
+
+        await this.sdk.sendCloseModal();
+
+        try {
+            await this.sdk.waitForCondition(state => {
+                return !state.trade?.isOpen && !state.trade?.isConfirmOpen;
+            }, 5000);
+
+            return { success: true, message: 'Trade declined' };
+        } catch {
+            return { success: false, message: 'Timeout waiting for trade to close', reason: 'timeout' };
+        }
     }
 }
 

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -604,6 +604,51 @@ export class BotSDK {
         return this.state?.bank.isOpen || false;
     }
 
+    // ============ Trade State Access ============
+
+    /** Check if trade window is currently open. */
+    isTradeOpen(): boolean {
+        return this.state?.trade?.isOpen || false;
+    }
+
+    /** Check if trade confirmation screen is open. */
+    isTradeConfirmOpen(): boolean {
+        return this.state?.trade?.isConfirmOpen || false;
+    }
+
+    /** Get the trade partner's name. */
+    getTradePartnerName(): string {
+        return this.state?.trade?.partnerName || '';
+    }
+
+    /** Get the current trade status text. */
+    getTradeStatusText(): string {
+        return this.state?.trade?.statusText || '';
+    }
+
+    /** Get items in your trade offer. */
+    getTradeMyOffer(): import('./types').TradeItem[] {
+        return this.state?.trade?.myOffer || [];
+    }
+
+    /** Get items in the other player's trade offer. */
+    getTradeTheirOffer(): import('./types').TradeItem[] {
+        return this.state?.trade?.theirOffer || [];
+    }
+
+    /** Get your inventory items shown in the trade side panel. */
+    getTradeMyInventory(): import('./types').TradeItem[] {
+        return this.state?.trade?.myInventory || [];
+    }
+
+    /** Find a trade item by name pattern in a trade item list. */
+    findTradeItem(pattern: string | RegExp, items: import('./types').TradeItem[]): import('./types').TradeItem | null {
+        const regex = typeof pattern === 'string'
+            ? new RegExp(pattern, 'i')
+            : pattern;
+        return items.find(i => regex.test(i.name)) || null;
+    }
+
     /** Get NPC by index. */
     getNearbyNpc(index: number): NearbyNpc | null {
         if (!this.state) return null;
@@ -622,6 +667,26 @@ export class BotSDK {
     /** Get all nearby NPCs. */
     getNearbyNpcs(): NearbyNpc[] {
         return this.state?.nearbyNpcs || [];
+    }
+
+    /** Get a nearby player by index. */
+    getNearbyPlayer(index: number): import('./types').NearbyPlayer | null {
+        if (!this.state) return null;
+        return this.state.nearbyPlayers.find(p => p.index === index) || null;
+    }
+
+    /** Find a nearby player by name pattern. */
+    findNearbyPlayer(pattern: string | RegExp): import('./types').NearbyPlayer | null {
+        if (!this.state) return null;
+        const regex = typeof pattern === 'string'
+            ? new RegExp(pattern, 'i')
+            : pattern;
+        return this.state.nearbyPlayers.find(p => regex.test(p.name)) || null;
+    }
+
+    /** Get all nearby players. */
+    getNearbyPlayers(): import('./types').NearbyPlayer[] {
+        return this.state?.nearbyPlayers || [];
     }
 
     /** Get location (object) by coordinates and ID. */
@@ -959,6 +1024,18 @@ export class BotSDK {
     /** Withdraw item from bank by slot. */
     async sendBankWithdraw(slot: number, amount: number = 1): Promise<ActionResult> {
         return this.sendAction({ type: 'bankWithdraw', slot, amount, reason: 'SDK' });
+    }
+
+    // ============ Trade Actions ============
+
+    /** Offer an item from your inventory in the trade window. Amount: 1/5/10/-1(all)/custom. */
+    async sendTradeOffer(slot: number, amount: number = 1): Promise<ActionResult> {
+        return this.sendAction({ type: 'tradeOffer', slot, amount, reason: 'SDK' });
+    }
+
+    /** Remove an item from your trade offer. Amount: 1/5/10/-1(all)/custom. */
+    async sendTradeRemove(slot: number, amount: number = 1): Promise<ActionResult> {
+        return this.sendAction({ type: 'tradeRemove', slot, amount, reason: 'SDK' });
     }
 
     // ============ Screenshot ============

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -193,6 +193,35 @@ export interface BankState {
     items: BankItem[];
 }
 
+export interface TradeItem {
+    slot: number;
+    id: number;
+    name: string;
+    count: number;
+}
+
+export interface TradeState {
+    isOpen: boolean;
+    isConfirmOpen: boolean;
+    partnerName: string;
+    statusText: string;
+    myOffer: TradeItem[];
+    theirOffer: TradeItem[];
+    myInventory: TradeItem[];
+}
+
+export interface TradeResult {
+    success: boolean;
+    message: string;
+    reason?: 'player_not_found' | 'cant_reach' | 'trade_not_opened' | 'declined' | 'timeout';
+}
+
+export interface TradeOfferResult {
+    success: boolean;
+    message: string;
+    reason?: 'trade_not_open' | 'item_not_found' | 'timeout';
+}
+
 export interface CombatStyleOption {
     index: number;
     name: string;
@@ -282,6 +311,7 @@ export interface BotWorldState {
     interface: InterfaceState;
     shop: ShopState;
     bank: BankState;
+    trade: TradeState;
     modalOpen: boolean;
     modalInterface: number;
     combatStyle?: CombatStyleState;
@@ -331,7 +361,9 @@ export type BotAction =
     | { type: 'bankWithdraw'; slot: number; amount: number; reason: string }
     | { type: 'scanNearbyLocs'; radius?: number; reason: string }
     | { type: 'scanGroundItems'; radius?: number; reason: string }
-    | { type: 'togglePrayer'; prayerIndex: number; reason: string };
+    | { type: 'togglePrayer'; prayerIndex: number; reason: string }
+    | { type: 'tradeOffer'; slot: number; amount: number; reason: string }
+    | { type: 'tradeRemove'; slot: number; amount: number; reason: string };
 
 export interface ActionResult {
     success: boolean;

--- a/server/webclient/src/bot/ActionExecutor.ts
+++ b/server/webclient/src/bot/ActionExecutor.ts
@@ -304,6 +304,26 @@ export class ActionExecutor {
                         data: this.scanProvider.scanGroundItems(action.radius)
                     };
 
+                case 'tradeOffer': {
+                    const needsCountDialog = action.amount !== 1 && action.amount !== 5 && action.amount !== 10 && action.amount !== -1 && action.amount < 2147483647;
+                    const tradeOfferOk = this.client.tradeOffer(action.slot, action.amount);
+                    if (!tradeOfferOk) return { success: false, message: 'Failed to offer trade item' };
+                    if (needsCountDialog) {
+                        return this.waitForCountDialogAndSubmit(action.amount, `Offering ${action.amount} from slot ${action.slot}`);
+                    }
+                    return { success: true, message: `Offering from slot ${action.slot}` };
+                }
+
+                case 'tradeRemove': {
+                    const needsCountDialog = action.amount !== 1 && action.amount !== 5 && action.amount !== 10 && action.amount !== -1 && action.amount < 2147483647;
+                    const tradeRemoveOk = this.client.tradeRemove(action.slot, action.amount);
+                    if (!tradeRemoveOk) return { success: false, message: 'Failed to remove trade item' };
+                    if (needsCountDialog) {
+                        return this.waitForCountDialogAndSubmit(action.amount, `Removing ${action.amount} from slot ${action.slot}`);
+                    }
+                    return { success: true, message: `Removing from slot ${action.slot}` };
+                }
+
                 case 'togglePrayer': {
                     if (!this.scanProvider) {
                         return { success: false, message: 'No scan provider available' };
@@ -400,6 +420,8 @@ export function formatAction(action: BotAction): string {
         case 'randomizeCharacterDesign': return 'Randomize character design';
         case 'say': return `Say: ${action.message}`;
         case 'togglePrayer': return `Toggle prayer ${action.prayerIndex}`;
+        case 'tradeOffer': return `Trade offer slot ${action.slot} x${action.amount}`;
+        case 'tradeRemove': return `Trade remove slot ${action.slot} x${action.amount}`;
         default: return action.type;
     }
 }

--- a/server/webclient/src/bot/StateCollector.ts
+++ b/server/webclient/src/bot/StateCollector.ts
@@ -18,6 +18,19 @@ import {
     EQUIPMENT_INTERFACE_ID,
     SHOP_TEMPLATE_INV_ID,
     SHOP_TEMPLATE_SIDE_INV_ID,
+    TRADE_MAIN_ID,
+    TRADE_SIDE_ID,
+    TRADE_SIDE_INV_ID,
+    TRADE_MY_OFFER_ID,
+    TRADE_THEIR_OFFER_ID,
+    TRADE_PARTNER_NAME_ID,
+    TRADE_STATUS_ID,
+    TRADE_CONFIRM_ID,
+    TRADE_CONFIRM_THEIR_INV1_ID,
+    TRADE_CONFIRM_STATUS_ID,
+    TRADE_CONFIRM_MY_INV2_ID,
+    TRADE_CONFIRM_THEIR_INV2_ID,
+    TRADE_CONFIRM_MY_INV1_ID,
     type BotState,
     type SkillState,
     type InventoryItem,
@@ -35,6 +48,8 @@ import {
     type ShopItem,
     type BankState,
     type BankItem,
+    type TradeItem,
+    type TradeState,
     type PlayerState,
     type CombatStyleState,
     type CombatStyleOption,
@@ -108,6 +123,7 @@ export class BotStateCollector implements ScanProvider {
             menuActions: this.collectMenuActions(),
             shop: this.collectShopState(),
             bank: this.collectBankState(),
+            trade: this.collectTradeState(),
             inGame: c.ingame || false,
             combatEvents: [...this.combatEvents], // Return copy of events
             dialog: this.collectDialogState(),
@@ -1050,6 +1066,97 @@ export class BotStateCollector implements ScanProvider {
         }
 
         return bankState;
+    }
+
+    private collectTradeState(): TradeState {
+        const c = this.client as any;
+        const defaultState: TradeState = {
+            isOpen: false,
+            isConfirmOpen: false,
+            partnerName: '',
+            statusText: '',
+            myOffer: [],
+            theirOffer: [],
+            myInventory: []
+        };
+
+        try {
+            const isTradeOpen = typeof c.isTradeOpen === 'function' ? c.isTradeOpen() : false;
+            const isConfirmOpen = typeof c.isTradeConfirmOpen === 'function' ? c.isTradeConfirmOpen() : false;
+
+            if (!isTradeOpen && !isConfirmOpen) {
+                return defaultState;
+            }
+
+            defaultState.isOpen = isTradeOpen;
+            defaultState.isConfirmOpen = isConfirmOpen;
+
+            // Get partner name
+            if (typeof c.getTradePartnerName === 'function') {
+                defaultState.partnerName = c.getTradePartnerName();
+            }
+
+            // Get status text
+            if (typeof c.getTradeStatusText === 'function') {
+                defaultState.statusText = c.getTradeStatusText();
+            }
+
+            if (isTradeOpen) {
+                // Main trade window
+                defaultState.myOffer = this.collectTradeInventory(TRADE_MY_OFFER_ID);
+                defaultState.theirOffer = this.collectTradeInventory(TRADE_THEIR_OFFER_ID);
+                defaultState.myInventory = this.collectTradeInventory(TRADE_SIDE_INV_ID);
+            } else if (isConfirmOpen) {
+                // Confirmation screen - server uses different components depending on item count
+                // Try both pairs and use whichever has items
+                let myItems = this.collectTradeInventory(TRADE_CONFIRM_MY_INV1_ID);
+                if (myItems.length === 0) {
+                    myItems = this.collectTradeInventory(TRADE_CONFIRM_MY_INV2_ID);
+                }
+                defaultState.myOffer = myItems;
+
+                let theirItems = this.collectTradeInventory(TRADE_CONFIRM_THEIR_INV1_ID);
+                if (theirItems.length === 0) {
+                    theirItems = this.collectTradeInventory(TRADE_CONFIRM_THEIR_INV2_ID);
+                }
+                defaultState.theirOffer = theirItems;
+            }
+        } catch { /* ignore errors */ }
+
+        return defaultState;
+    }
+
+    private collectTradeInventory(interfaceId: number): TradeItem[] {
+        const items: TradeItem[] = [];
+
+        try {
+            const component = IfType.list[interfaceId];
+            if (!component || !component.linkObjType || !component.linkObjNumber) {
+                return items;
+            }
+
+            for (let slot = 0; slot < component.linkObjType.length; slot++) {
+                const objId = component.linkObjType[slot];
+                const count = component.linkObjNumber[slot];
+
+                if (objId > 0) {
+                    let name = 'Unknown';
+                    try {
+                        const obj = ObjType.list(objId - 1);
+                        name = obj.name || 'Unknown';
+                    } catch { /* ignore */ }
+
+                    items.push({
+                        slot,
+                        id: objId - 1,
+                        name,
+                        count
+                    });
+                }
+            }
+        } catch { /* ignore errors */ }
+
+        return items;
     }
 
     /**

--- a/server/webclient/src/bot/types.ts
+++ b/server/webclient/src/bot/types.ts
@@ -24,6 +24,23 @@ export const BANK_MAIN_ID = 5292; // Main bank interface (mainModalId)
 export const BANK_MAIN_INV_ID = 5382; // Bank inventory component (bank_main:inv)
 export const BANK_SIDE_INV_ID = 2006; // Side panel inventory for depositing
 
+// Trade interface IDs
+export const TRADE_MAIN_ID = 3323; // Main trade window (mainModalId)
+export const TRADE_SIDE_ID = 3321; // Side panel (player inv during trade)
+export const TRADE_SIDE_INV_ID = 3322; // Inventory component in side panel (offer items from here)
+export const TRADE_MY_OFFER_ID = 3415; // Your offer items (remove items from here)
+export const TRADE_THEIR_OFFER_ID = 3416; // Other player's offer items
+export const TRADE_PARTNER_NAME_ID = 3417; // "Trading With: Name" text
+export const TRADE_ACCEPT_ID = 3420; // Accept button
+export const TRADE_STATUS_ID = 3431; // Status text
+export const TRADE_CONFIRM_ID = 3443; // Confirmation screen (mainModalId)
+export const TRADE_CONFIRM_THEIR_INV1_ID = 3532; // Their items (<14)
+export const TRADE_CONFIRM_STATUS_ID = 3535; // Confirm status text
+export const TRADE_CONFIRM_MY_INV2_ID = 3538; // Your items (>=14)
+export const TRADE_CONFIRM_THEIR_INV2_ID = 3539; // Their items (>=14)
+export const TRADE_CONFIRM_MY_INV1_ID = 3542; // Your items (<14)
+export const TRADE_CONFIRM_ACCEPT_ID = 3546; // Confirm accept button
+
 // Interfaces for state data
 export interface SkillState {
     name: string;
@@ -169,6 +186,23 @@ export interface BankState {
     items: BankItem[];
 }
 
+export interface TradeItem {
+    slot: number;
+    id: number;
+    name: string;
+    count: number;
+}
+
+export interface TradeState {
+    isOpen: boolean;
+    isConfirmOpen: boolean;
+    partnerName: string;
+    statusText: string;
+    myOffer: TradeItem[];
+    theirOffer: TradeItem[];
+    myInventory: TradeItem[];
+}
+
 /** Combat state tracking for player */
 export interface PlayerCombatState {
     /** Currently engaged in combat (has a target) */
@@ -271,6 +305,7 @@ export interface BotState {
     menuActions: MenuAction[];
     shop: ShopState;
     bank: BankState;
+    trade: TradeState;
     inGame: boolean;
     /** Recent combat events (damage, kills) - bounded to last ~50 ticks */
     combatEvents: CombatEvent[];
@@ -345,4 +380,7 @@ export type BotAction =
     | { type: 'scanNearbyLocs'; radius?: number; reason: string }
     | { type: 'scanGroundItems'; radius?: number; reason: string }
     // Prayer toggle
-    | { type: 'togglePrayer'; prayerIndex: number; reason: string };
+    | { type: 'togglePrayer'; prayerIndex: number; reason: string }
+    // Trade actions
+    | { type: 'tradeOffer'; slot: number; amount: number; reason: string }
+    | { type: 'tradeRemove'; slot: number; amount: number; reason: string };

--- a/server/webclient/src/client/Client.ts
+++ b/server/webclient/src/client/Client.ts
@@ -1636,6 +1636,144 @@ export class Client extends GameShell {
     }
 
     /**
+     * Check if trade window is currently open
+     */
+    isTradeOpen(): boolean {
+        return this.mainModalId === 3323 && this.sideModalId === 3321;
+    }
+
+    /**
+     * Check if trade confirmation screen is open
+     */
+    isTradeConfirmOpen(): boolean {
+        return this.mainModalId === 3443;
+    }
+
+    /**
+     * Get the trade partner's name from the trade interface
+     */
+    getTradePartnerName(): string {
+        try {
+            const com = IfType.list[3417];
+            if (com && com.text) {
+                // Strip "Trading With: " prefix
+                return com.text.replace(/^Trading With:\s*/i, '');
+            }
+        } catch { /* ignore */ }
+        return '';
+    }
+
+    /**
+     * Get the trade status text (e.g. "Other player has accepted", "Waiting for other player...")
+     */
+    getTradeStatusText(): string {
+        try {
+            const componentId = this.isTradeConfirmOpen() ? 3535 : 3431;
+            const com = IfType.list[componentId];
+            if (com && com.text) {
+                return com.text;
+            }
+        } catch { /* ignore */ }
+        return '';
+    }
+
+    /**
+     * Offer an item from the trade side inventory (your inventory during trade)
+     * slot: slot in tradeside:inv (3322)
+     * amount: 1, 5, 10, -1 (all), or custom (triggers count dialog)
+     */
+    tradeOffer(slot: number, amount: number = 1): boolean {
+        if (!this.ingame || !this.out || !this.isTradeOpen()) {
+            return false;
+        }
+
+        const TRADE_SIDE_INV_ID = 3322;
+        const component = IfType.list[TRADE_SIDE_INV_ID];
+        if (!component || !component.linkObjType) {
+            return false;
+        }
+
+        const rawItemId = component.linkObjType[slot];
+        if (!rawItemId || rawItemId <= 0) {
+            return false;
+        }
+
+        const obj = ObjType.list(rawItemId - 1);
+        const itemId = obj.id;
+
+        // Map amount to option index: 1->1, 5->2, 10->3, all->4, X->5
+        let optionIndex = 1;
+        if (amount === 5) optionIndex = 2;
+        else if (amount === 10) optionIndex = 3;
+        else if (amount === -1 || amount >= 2147483647) optionIndex = 4;
+        else if (amount !== 1) optionIndex = 5;
+
+        const opcodes = [
+            ClientProt.INV_BUTTON1,
+            ClientProt.INV_BUTTON2,
+            ClientProt.INV_BUTTON3,
+            ClientProt.INV_BUTTON4,
+            ClientProt.INV_BUTTON5
+        ];
+
+        this.writePacketOpcode(opcodes[optionIndex - 1]);
+        this.out.p2(itemId);
+        this.out.p2(slot);
+        this.out.p2(TRADE_SIDE_INV_ID);
+
+        console.log(`[Client] tradeOffer: slot=${slot}, itemId=${itemId}, amount=${amount}, optionIndex=${optionIndex}`);
+        return true;
+    }
+
+    /**
+     * Remove an item from your trade offer
+     * slot: slot in trademain:inv (3415)
+     * amount: 1, 5, 10, -1 (all), or custom (triggers count dialog)
+     */
+    tradeRemove(slot: number, amount: number = 1): boolean {
+        if (!this.ingame || !this.out || !this.isTradeOpen()) {
+            return false;
+        }
+
+        const TRADE_MY_OFFER_ID = 3415;
+        const component = IfType.list[TRADE_MY_OFFER_ID];
+        if (!component || !component.linkObjType) {
+            return false;
+        }
+
+        const rawItemId = component.linkObjType[slot];
+        if (!rawItemId || rawItemId <= 0) {
+            return false;
+        }
+
+        const obj = ObjType.list(rawItemId - 1);
+        const itemId = obj.id;
+
+        // Map amount to option index: 1->1, 5->2, 10->3, all->4, X->5
+        let optionIndex = 1;
+        if (amount === 5) optionIndex = 2;
+        else if (amount === 10) optionIndex = 3;
+        else if (amount === -1 || amount >= 2147483647) optionIndex = 4;
+        else if (amount !== 1) optionIndex = 5;
+
+        const opcodes = [
+            ClientProt.INV_BUTTON1,
+            ClientProt.INV_BUTTON2,
+            ClientProt.INV_BUTTON3,
+            ClientProt.INV_BUTTON4,
+            ClientProt.INV_BUTTON5
+        ];
+
+        this.writePacketOpcode(opcodes[optionIndex - 1]);
+        this.out.p2(itemId);
+        this.out.p2(slot);
+        this.out.p2(TRADE_MY_OFFER_ID);
+
+        console.log(`[Client] tradeRemove: slot=${slot}, itemId=${itemId}, amount=${amount}, optionIndex=${optionIndex}`);
+        return true;
+    }
+
+    /**
      * Set combat style (0-3)
      */
     setCombatStyle(style: number): boolean {


### PR DESCRIPTION
## Summary
- Adds full trade window state tracking and interaction methods across all 4 stack layers (webclient, SDK, MCP docs)
- Follows the same patterns used by existing shop and bank systems
- 700 lines across 11 files: webclient types/Client/StateCollector/ActionExecutor, SDK types/index/actions/actions-helpers, MCP API docs

## High-level bot methods added
- `bot.requestTrade(target)` - Request trade with nearby player
- `bot.offerItem(target, amount)` - Offer inventory item in trade window
- `bot.removeOffer(target, amount)` - Remove item from your offer
- `bot.acceptTrade()` - Accept trade (first screen)
- `bot.confirmTrade()` - Confirm trade (second screen, finalizes)
- `bot.declineTrade()` - Decline/close trade window

## SDK methods added
- Trade state accessors: `isTradeOpen()`, `isTradeConfirmOpen()`, `getTradePartnerName()`, `getTradeMyOffer()`, `getTradeTheirOffer()`
- Player lookups: `findNearbyPlayer(pattern)`, `getNearbyPlayer(index)`
- Trade actions: `sendTradeOffer(slot, amount)`, `sendTradeRemove(slot, amount)`

## Test plan
- [x] Tested end-to-end with two bots (trade1/trade2) on localhost
- [x] Bronze sword successfully transferred from trade1 to trade2
- [x] Trade state correctly reports isOpen, partnerName, myOffer, theirOffer
- [x] Accept → confirm → trade complete flow works
- [ ] Test decline flow
- [ ] Test error cases (non-existent player, non-tradeable item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)