### PR TITLE
Harden MCP execution sessions and add structured agent tools

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,7 @@
 # RS-Agent MCP Server
 
-MCP (Model Context Protocol) server for controlling RS-Agent bots. Supports multiple simultaneous bot connections.
+MCP (Model Context Protocol) server for controlling RS-Agent bots. Supports
+multiple bot connections and serializes mutations made to the same bot.
 
 ## Quick Start (Claude Code)
 
@@ -26,7 +27,9 @@ Claude Code auto-discovers the MCP server via `.mcp.json`. Just:
 ## Tools
 
 ### `execute_code`
-Execute TypeScript code on a bot. Auto-connects on first use using credentials from `bots/{name}/bot.env`.
+Execute TypeScript code on a bot. Auto-connects on first use using credentials
+from `bots/{name}/bot.env`. TypeScript is transpiled before execution, so
+annotations, interfaces, and non-null assertions are accepted.
 
 ```typescript
 execute_code({
@@ -42,12 +45,83 @@ execute_code({
 })
 ```
 
+The body runs as an async function with four arguments:
+
+- `bot`: high-level `BotActions`
+- `sdk`: low-level `BotSDK`
+- `console`: request-scoped output captured in the response
+- `signal`: an `AbortSignal` fired by timeout or MCP client cancellation
+
+Calls are FIFO-serialized per bot. Output and console capture are bounded.
+Errors and timeouts retain console output and a terminal world-state snapshot.
+Once an execution is cancelled it cannot start another proxied SDK call. An
+SDK call that had already started cannot currently be interrupted because the
+public SDK does not accept `AbortSignal`; in that case the response says so and
+the per-bot queue remains locked until the call settles.
+
+Cancellation is cooperative: it cannot pre-empt CPU-bound synchronous
+JavaScript that blocks Bun's event loop. Code bodies are limited to 262,144
+characters.
+
+> **Trusted-code boundary:** `execute_code` is not a sandbox. Code runs with the
+> MCP server process's filesystem, process, and network permissions. Do not
+> expose this tool to untrusted callers.
+
+### `inspect_state`
+
+Read full or selected structured state without arbitrary code. The response
+always includes connection and freshness metadata. Unlike action tools, it can
+return a stale cached snapshot so a stopped browser can be diagnosed.
+
+```typescript
+inspect_state({
+  bot_name: "mybot",
+  sections: ["player", "inventory", "nearby_npcs"]
+})
+```
+
+`inspect_state` is the supported, more complete replacement for the old
+`get_state` proposal.
+
+### `query_entities`
+
+Query typed NPC, player, location, ground-item, or inventory records with
+literal-name, regex, option, and distance filters. Locations and ground items
+can request an on-demand scan.
+
+```typescript
+query_entities({
+  bot_name: "mybot",
+  kind: "npc",
+  name: "cow",
+  option: "attack",
+  max_distance: 12
+})
+```
+
+### `perform_action`
+
+Perform one validated high-level action without generating code. Supported
+operations include walking, talking/interacting, combat, pickup, woodcutting,
+doors, banking, food, chat, waiting, blocking-UI dismissal, and tutorial skip.
+
+```typescript
+perform_action({
+  bot_name: "mybot",
+  action: "interact_npc",
+  target: "banker",
+  option: "bank"
+})
+```
+
 ### `list_bots`
-List all connected bots and their status.
+List all bot sessions and their transport, authentication, state freshness,
+control mode, controller/observer, and execution-lock status.
 
 ```typescript
 list_bots()
-// Returns: { bots: [{ name: "mybot", username: "mybot", connected: true }], count: 1 }
+// Includes connected, authenticated, connectionState, stateAgeMs,
+// sessionStatus, controllers, observers, and executionBusy.
 ```
 
 ### `disconnect_bot`
@@ -59,11 +133,12 @@ disconnect_bot({ name: "mybot" })
 
 ## Resources
 
-The server exposes API documentation as a resource:
+The server exposes API documentation as an exact, allowlisted resource:
 
 - `file://../sdk/API.md` — Auto-generated reference for `bot.*` (high-level actions) and `sdk.*` (low-level SDK)
 
-Read this to discover available methods.
+Read this to discover available methods. Other `file://` URIs, including path
+traversal and absolute paths, are rejected.
 
 ## Multiple Bots
 
@@ -108,6 +183,10 @@ bun run mcp/server.ts
 ```
 mcp/
 ├── server.ts           # MCP server (stdio transport)
+├── execution.ts        # TypeScript execution, cancellation, logs, per-bot queue
+├── agent-tools.ts      # Structured state/query/action tools
+├── output.ts           # Bounded output and terminal snapshots
+├── resources.ts        # Exact resource allowlist
 └── api/
     └── index.ts        # BotManager - manages multiple connections
 ```
@@ -122,11 +201,23 @@ The `@modelcontextprotocol/sdk` dependency lives in the root `package.json`.
 
 **"Bot is not connected"**
 - Bots auto-connect on the first `execute_code` call — check the error output for connection failures
-- Use `list_bots` to see connected bots
+- Use `list_bots` to distinguish gateway connection, authentication, stale
+  browser state, and controller pre-emption
 
 **"Connection failed"**
 - Check the gateway is running
 - Verify credentials in `bots/{name}/bot.env`
+
+**"No fresh game state"**
+- Open or reload the bot browser and confirm the character is logged in
+- Check `stateAgeMs` and `sessionStatus` with `list_bots`
+
+## Development checks
+
+```bash
+bun test mcp/*.test.ts
+bun x tsc -p mcp/tsconfig.json
+```
 
 **MCP server not appearing in Claude Code**
 - Run `bun install` at the project root

--- a/mcp/agent-tools.test.ts
+++ b/mcp/agent-tools.test.ts
@@ -34,7 +34,7 @@ function fakeConnection(overrides: {
     bot: overrides.bot ?? {},
     username: 'tester',
     connected: true,
-    lastShownMessageTick: -1,
+    lastShownMessageCursor: -1,
   } as unknown as BotConnection;
 }
 

--- a/mcp/agent-tools.test.ts
+++ b/mcp/agent-tools.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'bun:test';
+import { AGENT_TOOL_DEFINITIONS, inspectState, performAction, queryEntities } from './agent-tools';
+import type { BotConnection } from './api';
+
+function fakeConnection(overrides: {
+  state?: Record<string, unknown> | null;
+  npcs?: Array<Record<string, unknown>>;
+  bot?: Record<string, unknown>;
+} = {}): BotConnection {
+  const state = overrides.state === undefined
+    ? {
+        tick: 10,
+        inGame: true,
+        player: { name: 'tester', worldX: 3200, worldZ: 3200 },
+        nearbyPlayers: [],
+      }
+    : overrides.state;
+  const sdk = {
+    getState: () => state,
+    getStateReceivedAt: () => state ? Date.now() - 25 : 0,
+    getStateAge: () => state ? 25 : 0,
+    isConnected: () => true,
+    isAuthenticated: () => true,
+    getConnectionState: () => 'connected',
+    getConnectionMode: () => 'control',
+    getNearbyNpcs: () => overrides.npcs ?? [],
+    getNearbyLocs: () => [],
+    getGroundItems: () => [],
+    getInventory: () => [],
+    getNearbyNpc: (index: number) => (overrides.npcs ?? []).find(npc => npc.index === index) ?? null,
+  };
+  return {
+    sdk,
+    bot: overrides.bot ?? {},
+    username: 'tester',
+    connected: true,
+    lastShownMessageTick: -1,
+  } as unknown as BotConnection;
+}
+
+describe('structured agent tools', () => {
+  test('exposes state, query, and action tools', () => {
+    expect(AGENT_TOOL_DEFINITIONS.map(tool => tool.name))
+      .toEqual(['inspect_state', 'query_entities', 'perform_action']);
+  });
+
+  test('inspect_state reports missing state instead of hiding freshness metadata', () => {
+    const result = inspectState(fakeConnection({ state: null })) as any;
+    expect(result.state).toBeNull();
+    expect(result.metadata.stateAgeMs).toBeNull();
+    expect(result.warning).toContain('No game state');
+  });
+
+  test('query_entities applies literal name, option, distance, and limit filters', async () => {
+    const connection = fakeConnection({
+      npcs: [
+        { index: 1, name: 'Cow', distance: 4, options: ['Attack', 'Examine'] },
+        { index: 2, name: 'Cow calf', distance: 8, options: ['Attack'] },
+        { index: 3, name: 'Cow', distance: 2, options: ['Talk-to'] },
+      ],
+    });
+    const result = await queryEntities(connection, {
+      kind: 'npc',
+      name: 'cow',
+      option: 'attack',
+      max_distance: 6,
+      limit: 1,
+    }) as any;
+
+    expect(result.count).toBe(1);
+    expect(result.entities[0].index).toBe(1);
+  });
+
+  test('perform_action resolves an NPC index and calls the high-level action', async () => {
+    let targetIndex = -1;
+    const connection = fakeConnection({
+      npcs: [{ index: 7, name: 'Banker', distance: 1, options: ['Talk-to'] }],
+      bot: {
+        talkTo: async (target: { index: number }) => {
+          targetIndex = target.index;
+          return { success: true, message: 'Dialog opened' };
+        },
+      },
+    });
+    const result = await performAction(connection, {
+      action: 'talk_to',
+      target_index: 7,
+    }) as any;
+
+    expect(targetIndex).toBe(7);
+    expect(result.result.success).toBe(true);
+  });
+
+  test('perform_action rejects missing action-specific arguments', async () => {
+    await expect(performAction(fakeConnection(), { action: 'walk_to', x: 3200 }))
+      .rejects.toThrow('z must be a finite number');
+  });
+});

--- a/mcp/agent-tools.ts
+++ b/mcp/agent-tools.ts
@@ -1,0 +1,462 @@
+import type { BotConnection } from './api';
+
+export const INSPECT_STATE_SECTIONS = [
+  'player',
+  'skills',
+  'inventory',
+  'equipment',
+  'nearby_npcs',
+  'nearby_players',
+  'nearby_locations',
+  'ground_items',
+  'dialog',
+  'interface',
+  'bank',
+  'shop',
+  'messages',
+  'combat_events',
+  'prayers',
+] as const;
+
+type InspectSection = typeof INSPECT_STATE_SECTIONS[number];
+type ToolArguments = Record<string, unknown>;
+
+export const AGENT_TOOL_DEFINITIONS = [
+  {
+    name: 'inspect_state',
+    description: 'Get typed game state without executing arbitrary code. Returns freshness and connection metadata plus the full state or selected sections. This supersedes the older get_state proposal.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        bot_name: { type: 'string', description: 'Bot name (matches bots/{name}/).' },
+        sections: {
+          type: 'array',
+          items: { type: 'string', enum: [...INSPECT_STATE_SECTIONS] },
+          uniqueItems: true,
+          description: 'Optional sections to return. Omit for the complete state.',
+        },
+      },
+      required: ['bot_name'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'query_entities',
+    description: 'Query nearby NPCs, players, locations, ground items, or inventory with typed filters. Location and ground-item queries may request an on-demand scan.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        bot_name: { type: 'string', description: 'Bot name (matches bots/{name}/).' },
+        kind: {
+          type: 'string',
+          enum: ['npc', 'player', 'location', 'ground_item', 'inventory_item'],
+        },
+        name: { type: 'string', description: 'Case-insensitive literal name substring.' },
+        name_pattern: { type: 'string', description: 'Optional JavaScript regular expression; cannot be combined with name.' },
+        option: { type: 'string', description: 'Require an interaction option containing this text.' },
+        max_distance: { type: 'number', minimum: 0 },
+        scan_radius: {
+          type: 'number',
+          minimum: 1,
+          maximum: 64,
+          description: 'On-demand scan radius; supported for location and ground_item.',
+        },
+        limit: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+      },
+      required: ['bot_name', 'kind'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'perform_action',
+    description: 'Perform one validated high-level bot action. Calls for the same bot are serialized. Results inherit the completion guarantees of the named BotActions method.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        bot_name: { type: 'string', description: 'Bot name (matches bots/{name}/).' },
+        action: {
+          type: 'string',
+          enum: [
+            'walk_to',
+            'talk_to',
+            'interact_npc',
+            'interact_location',
+            'attack_npc',
+            'pickup_item',
+            'chop_tree',
+            'open_door',
+            'open_bank',
+            'deposit_item',
+            'withdraw_item',
+            'eat_food',
+            'say',
+            'wait_ticks',
+            'dismiss_blocking_ui',
+            'skip_tutorial',
+          ],
+        },
+        target: { type: 'string', description: 'Case-insensitive literal target-name substring.' },
+        target_index: { type: 'integer', minimum: 0, description: 'Nearby NPC index, where supported.' },
+        x: { type: 'integer', description: 'Destination world X for walk_to.' },
+        z: { type: 'integer', description: 'Destination world Z for walk_to.' },
+        tolerance: { type: 'integer', minimum: 0, maximum: 20, default: 3 },
+        option: {
+          oneOf: [{ type: 'string' }, { type: 'integer', minimum: 1 }],
+          description: 'Interaction option text or protocol option index.',
+        },
+        amount: { type: 'integer', description: 'Item quantity; -1 means all where supported.' },
+        slot: { type: 'integer', minimum: 0, description: 'Bank slot for withdraw_item.' },
+        timeout_ms: { type: 'integer', minimum: 100, maximum: 120000 },
+        text: { type: 'string', description: 'Chat text for say.' },
+        ticks: { type: 'integer', minimum: 1, maximum: 1000 },
+        randomize_appearance: { type: 'boolean', default: true },
+      },
+      required: ['bot_name', 'action'],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+const SECTION_FIELDS: Record<InspectSection, string> = {
+  player: 'player',
+  skills: 'skills',
+  inventory: 'inventory',
+  equipment: 'equipment',
+  nearby_npcs: 'nearbyNpcs',
+  nearby_players: 'nearbyPlayers',
+  nearby_locations: 'nearbyLocs',
+  ground_items: 'groundItems',
+  dialog: 'dialog',
+  interface: 'interface',
+  bank: 'bank',
+  shop: 'shop',
+  messages: 'gameMessages',
+  combat_events: 'combatEvents',
+  prayers: 'prayers',
+};
+
+export function inspectState(connection: BotConnection, sections?: string[]): unknown {
+  const state = connection.sdk.getState();
+  const metadata = connectionMetadata(connection);
+  if (!state) {
+    return {
+      metadata,
+      state: null,
+      warning: 'No game state has been received. Open or reload the bot browser and confirm the character is logged in.',
+    };
+  }
+
+  if (!sections || sections.length === 0) {
+    return { metadata, state };
+  }
+
+  const selected: Record<string, unknown> = {};
+  for (const requested of sections) {
+    if (!isInspectSection(requested)) {
+      throw new Error(`Unknown state section "${requested}"`);
+    }
+    const field = SECTION_FIELDS[requested];
+    selected[requested] = (state as unknown as Record<string, unknown>)[field];
+  }
+  return { metadata, state: selected };
+}
+
+export async function queryEntities(connection: BotConnection, args: ToolArguments): Promise<unknown> {
+  const kind = requireEnum(args.kind, 'kind', [
+    'npc',
+    'player',
+    'location',
+    'ground_item',
+    'inventory_item',
+  ] as const);
+  const name = optionalString(args.name, 'name');
+  const patternText = optionalString(args.name_pattern, 'name_pattern');
+  if (name && patternText) throw new Error('Use either name or name_pattern, not both');
+
+  let namePattern: RegExp | null = null;
+  if (patternText) {
+    try {
+      namePattern = new RegExp(patternText, 'i');
+    } catch (error) {
+      throw new Error(`Invalid name_pattern: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  const option = optionalString(args.option, 'option')?.toLowerCase();
+  const maxDistance = optionalNumberInRange(args.max_distance, 'max_distance', 0, Infinity);
+  const scanRadius = optionalInteger(args.scan_radius, 'scan_radius', 1, 64);
+  const limit = optionalInteger(args.limit, 'limit', 1, 100) ?? 20;
+
+  if (scanRadius !== undefined && kind !== 'location' && kind !== 'ground_item') {
+    throw new Error('scan_radius is only valid for location and ground_item queries');
+  }
+
+  let entities: Array<Record<string, unknown>>;
+  switch (kind) {
+    case 'npc':
+      entities = connection.sdk.getNearbyNpcs() as unknown as Array<Record<string, unknown>>;
+      break;
+    case 'player':
+      entities = (connection.sdk.getState()?.nearbyPlayers ?? []) as unknown as Array<Record<string, unknown>>;
+      break;
+    case 'location':
+      entities = (scanRadius === undefined
+        ? connection.sdk.getNearbyLocs()
+        : await connection.sdk.scanNearbyLocs(scanRadius)) as unknown as Array<Record<string, unknown>>;
+      break;
+    case 'ground_item':
+      entities = (scanRadius === undefined
+        ? connection.sdk.getGroundItems()
+        : await connection.sdk.scanGroundItems(scanRadius)) as unknown as Array<Record<string, unknown>>;
+      break;
+    case 'inventory_item':
+      entities = connection.sdk.getInventory() as unknown as Array<Record<string, unknown>>;
+      break;
+  }
+
+  const filtered = entities
+    .filter(entity => {
+      const entityName = String(entity.name ?? '');
+      if (name && !entityName.toLowerCase().includes(name.toLowerCase())) return false;
+      if (namePattern && !namePattern.test(entityName)) return false;
+      if (maxDistance !== undefined && typeof entity.distance === 'number' && entity.distance > maxDistance) return false;
+      if (option) {
+        const options = Array.isArray(entity.options)
+          ? entity.options
+          : Array.isArray(entity.optionsWithIndex)
+            ? (entity.optionsWithIndex as Array<{ text?: unknown }>).map(entry => entry.text)
+            : [];
+        if (!options.some(value => String(value).toLowerCase().includes(option))) return false;
+      }
+      return true;
+    })
+    .sort((left, right) => {
+      const leftDistance = typeof left.distance === 'number' ? left.distance : 0;
+      const rightDistance = typeof right.distance === 'number' ? right.distance : 0;
+      return leftDistance - rightDistance;
+    })
+    .slice(0, Math.floor(limit));
+
+  return {
+    metadata: connectionMetadata(connection),
+    query: { kind, name: name ?? null, namePattern: patternText ?? null, option: option ?? null, maxDistance: maxDistance ?? null, scanRadius: scanRadius ?? null },
+    count: filtered.length,
+    entities: filtered,
+  };
+}
+
+export async function performAction(connection: BotConnection, args: ToolArguments): Promise<unknown> {
+  const action = requireEnum(args.action, 'action', [
+    'walk_to',
+    'talk_to',
+    'interact_npc',
+    'interact_location',
+    'attack_npc',
+    'pickup_item',
+    'chop_tree',
+    'open_door',
+    'open_bank',
+    'deposit_item',
+    'withdraw_item',
+    'eat_food',
+    'say',
+    'wait_ticks',
+    'dismiss_blocking_ui',
+    'skip_tutorial',
+  ] as const);
+
+  const target = optionalString(args.target, 'target');
+  const targetIndex = optionalInteger(args.target_index, 'target_index', 0, Infinity);
+  const option = args.option;
+  let result: unknown;
+
+  switch (action) {
+    case 'walk_to':
+      result = await connection.bot.walkTo(
+        requireInteger(args.x, 'x'),
+        requireInteger(args.z, 'z'),
+        optionalInteger(args.tolerance, 'tolerance', 0, 20) ?? 3,
+      );
+      break;
+    case 'talk_to':
+      result = await connection.bot.talkTo(resolveNpcTarget(connection, target, targetIndex));
+      break;
+    case 'interact_npc':
+      result = await connection.bot.interactNpc(
+        resolveNpcTarget(connection, target, targetIndex),
+        normalizeOption(option),
+      );
+      break;
+    case 'interact_location':
+      result = await connection.bot.interactLoc(
+        literalPattern(requireTarget(target)),
+        normalizeOption(option),
+      );
+      break;
+    case 'attack_npc':
+      result = await connection.bot.attackNpc(
+        resolveNpcTarget(connection, target, targetIndex),
+        optionalInteger(args.timeout_ms, 'timeout_ms', 100, 120_000) ?? 5_000,
+      );
+      break;
+    case 'pickup_item':
+      result = await connection.bot.pickupItem(literalPattern(requireTarget(target)));
+      break;
+    case 'chop_tree':
+      result = await connection.bot.chopTree(target ? literalPattern(target) : undefined);
+      break;
+    case 'open_door':
+      result = await connection.bot.openDoor(target ? literalPattern(target) : undefined);
+      break;
+    case 'open_bank':
+      result = await connection.bot.openBank(optionalInteger(args.timeout_ms, 'timeout_ms', 100, 120_000) ?? 10_000);
+      break;
+    case 'deposit_item':
+      result = await connection.bot.depositItem(
+        literalPattern(requireTarget(target)),
+        optionalInteger(args.amount, 'amount', -1, Infinity) ?? -1,
+      );
+      break;
+    case 'withdraw_item': {
+      const slot = optionalInteger(args.slot, 'slot', 0, Infinity);
+      if (slot === undefined && !target) throw new Error('withdraw_item requires slot or target');
+      result = await connection.bot.withdrawItem(
+        slot ?? literalPattern(target!),
+        optionalInteger(args.amount, 'amount', -1, Infinity) ?? 1,
+      );
+      break;
+    }
+    case 'eat_food':
+      result = await connection.bot.eatFood(literalPattern(requireTarget(target)));
+      break;
+    case 'say':
+      result = await connection.sdk.say(requireString(args.text, 'text'));
+      break;
+    case 'wait_ticks':
+      await connection.sdk.waitForTicks(optionalInteger(args.ticks, 'ticks', 1, 1_000) ?? 1);
+      result = { success: true, message: 'Wait complete' };
+      break;
+    case 'dismiss_blocking_ui':
+      await connection.bot.dismissBlockingUI();
+      result = { success: true, message: 'Blocking UI dismissed when safe' };
+      break;
+    case 'skip_tutorial':
+      result = await connection.bot.skipTutorial({
+        randomizeAppearance: optionalBoolean(args.randomize_appearance, 'randomize_appearance') ?? true,
+      });
+      break;
+  }
+
+  return {
+    action,
+    result,
+    metadata: connectionMetadata(connection),
+  };
+}
+
+export function connectionMetadata(connection: BotConnection): Record<string, unknown> {
+  const state = connection.sdk.getState();
+  return {
+    username: connection.username,
+    connected: connection.sdk.isConnected(),
+    authenticated: connection.sdk.isAuthenticated(),
+    connectionState: connection.sdk.getConnectionState(),
+    connectionMode: connection.sdk.getConnectionMode(),
+    stateAgeMs: state && connection.sdk.getStateReceivedAt() > 0
+      ? connection.sdk.getStateAge()
+      : null,
+    tick: state?.tick ?? null,
+    inGame: state?.inGame ?? null,
+  };
+}
+
+function resolveNpcTarget(connection: BotConnection, target?: string, targetIndex?: number) {
+  if (targetIndex !== undefined) {
+    const npc = connection.sdk.getNearbyNpc(targetIndex);
+    if (!npc) throw new Error(`Nearby NPC index ${targetIndex} was not found`);
+    return npc;
+  }
+  return literalPattern(requireTarget(target));
+}
+
+function normalizeOption(value: unknown): number | RegExp {
+  if (value === undefined) return 1;
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 1) return value;
+  if (typeof value === 'string' && value.length > 0) return literalPattern(value);
+  throw new Error('option must be a non-empty string or a positive integer');
+}
+
+function literalPattern(value: string): RegExp {
+  return new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
+}
+
+function requireTarget(value?: string): string {
+  if (!value) throw new Error('target is required for this action');
+  return value;
+}
+
+function isInspectSection(value: string): value is InspectSection {
+  return (INSPECT_STATE_SECTIONS as readonly string[]).includes(value);
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${field} must be a non-empty string`);
+  return value;
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requireString(value, field);
+}
+
+function requireNumber(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) throw new Error(`${field} must be a finite number`);
+  return value;
+}
+
+function requireInteger(value: unknown, field: string): number {
+  const number = requireNumber(value, field);
+  if (!Number.isInteger(number)) throw new Error(`${field} must be an integer`);
+  return number;
+}
+
+function optionalInteger(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const number = requireInteger(value, field);
+  if (number < min || number > max) {
+    throw new Error(`${field} must be between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function optionalNumberInRange(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  const number = requireNumber(value, field);
+  if (number < min || number > max) {
+    throw new Error(`${field} must be between ${min} and ${max}`);
+  }
+  return number;
+}
+
+function optionalBoolean(value: unknown, field: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') throw new Error(`${field} must be a boolean`);
+  return value;
+}
+
+function requireEnum<const T extends readonly string[]>(value: unknown, field: string, values: T): T[number] {
+  if (typeof value !== 'string' || !values.includes(value)) {
+    throw new Error(`${field} must be one of: ${values.join(', ')}`);
+  }
+  return value as T[number];
+}

--- a/mcp/api/index.test.ts
+++ b/mcp/api/index.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { BotManager, type BotConnection } from './index';
+
+function installConnection(manager: BotManager, options: {
+  ageMs?: number;
+  connected?: boolean;
+  authenticated?: boolean;
+  sessionStatus?: 'active' | 'stale' | 'dead';
+} = {}) {
+  let receivedAt = Date.now() - (options.ageMs ?? 20);
+  let socketConnected = options.connected ?? true;
+  let authenticated = options.authenticated ?? true;
+  let connectCalls = 0;
+  let disconnectCalls = 0;
+  const state = {
+    tick: 44,
+    inGame: true,
+    player: { name: 'tester', worldX: 3200, worldZ: 3201 },
+  };
+
+  const sdk = {
+    isConnected: () => socketConnected,
+    isAuthenticated: () => authenticated,
+    getConnectionState: () => socketConnected ? 'connected' : 'disconnected',
+    getConnectionMode: () => 'control',
+    getReconnectAttempt: () => 0,
+    getState: () => state,
+    getStateReceivedAt: () => receivedAt,
+    getStateAge: () => Date.now() - receivedAt,
+    checkBotStatus: async () => ({
+      status: options.sessionStatus ?? 'active',
+      inGame: true,
+      stateAge: Date.now() - receivedAt,
+      controllers: ['sdk-controller'],
+      observers: ['observer-1'],
+      player: state.player,
+    }),
+    disconnect: async () => {
+      disconnectCalls++;
+      socketConnected = false;
+      authenticated = false;
+    },
+    connect: async () => {
+      connectCalls++;
+      socketConnected = true;
+      authenticated = true;
+      receivedAt = Date.now();
+    },
+    waitForCondition: async (predicate: (value: typeof state) => boolean) => {
+      if (!predicate(state)) throw new Error('not ready');
+      return state;
+    },
+  };
+
+  const connection = {
+    sdk,
+    bot: {},
+    username: 'tester',
+    connected: socketConnected,
+    lastShownMessageTick: -1,
+  } as unknown as BotConnection;
+  (manager as any).connections.set('tester', connection);
+
+  return {
+    connection,
+    get connectCalls() { return connectCalls; },
+    get disconnectCalls() { return disconnectCalls; },
+  };
+}
+
+describe('BotManager health and diagnostics', () => {
+  test('lists transport, state freshness, mode, and controller details', async () => {
+    const manager = new BotManager();
+    installConnection(manager);
+
+    const [summary] = await manager.list();
+    expect(summary).toMatchObject({
+      name: 'tester',
+      connected: true,
+      authenticated: true,
+      connectionState: 'connected',
+      connectionMode: 'control',
+      hasState: true,
+      inGame: true,
+      tick: 44,
+      sessionStatus: 'active',
+      controllers: ['sdk-controller'],
+      observers: ['observer-1'],
+    });
+    expect(summary!.stateAgeMs).toBeLessThan(1_000);
+  });
+
+  test('reuses a fresh authenticated connection', async () => {
+    const manager = new BotManager();
+    const fixture = installConnection(manager, { ageMs: 50 });
+
+    expect(await manager.ensureHealthy('tester')).toBe(fixture.connection);
+    expect(fixture.connectCalls).toBe(0);
+    expect(fixture.disconnectCalls).toBe(0);
+  });
+
+  test('reconnects a stale cached connection before mutation', async () => {
+    const manager = new BotManager();
+    const fixture = installConnection(manager, {
+      ageMs: 30_000,
+      sessionStatus: 'stale',
+    });
+
+    expect(await manager.ensureHealthy('tester')).toBe(fixture.connection);
+    expect(fixture.disconnectCalls).toBe(1);
+    expect(fixture.connectCalls).toBe(1);
+  });
+});

--- a/mcp/api/index.test.ts
+++ b/mcp/api/index.test.ts
@@ -57,7 +57,7 @@ function installConnection(manager: BotManager, options: {
     bot: {},
     username: 'tester',
     connected: socketConnected,
-    lastShownMessageTick: -1,
+    lastShownMessageCursor: -1,
   } as unknown as BotConnection;
   (manager as any).connections.set('tester', connection);
 

--- a/mcp/api/index.ts
+++ b/mcp/api/index.ts
@@ -6,6 +6,7 @@ import { BotActions } from '../../sdk/actions';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import type { BotStatus, ConnectionState, SDKConnectionMode, SessionStatus } from '../../sdk/types';
 
 export interface BotConnection {
   sdk: BotSDK;
@@ -21,7 +22,34 @@ export interface BotConnection {
   lastShownMessageTick: number;
 }
 
-class BotManager {
+export interface BotConnectionSummary {
+  name: string;
+  username: string;
+  connected: boolean;
+  authenticated: boolean;
+  connectionState: ConnectionState;
+  connectionMode: SDKConnectionMode;
+  reconnectAttempt: number;
+  hasState: boolean;
+  stateAgeMs: number | null;
+  inGame: boolean | null;
+  tick: number | null;
+  player: { name: string; worldX: number; worldZ: number } | null;
+  sessionStatus: SessionStatus | 'unknown';
+  controllers: string[];
+  observers: string[];
+}
+
+export interface EnsureHealthyOptions {
+  /** Require a current game snapshot, not merely an authenticated gateway. */
+  requireFreshState?: boolean;
+  /** Maximum acceptable local state age. */
+  maxStateAgeMs?: number;
+  /** Time allowed for a state to become fresh after connection/reconnection. */
+  readyTimeoutMs?: number;
+}
+
+export class BotManager {
   private connections: Map<string, BotConnection> = new Map();
   private defaultGatewayUrl = 'ws://localhost:7780';
 
@@ -49,9 +77,9 @@ class BotManager {
 
     // Load credentials from bot.env if no password provided
     if (!password) {
-      // Try cwd first, then fall back to the repo root (one level up from mcp/)
+      // Try cwd first, then fall back to the repository root from mcp/api/.
       const cwdPath = join(process.cwd(), 'bots', name, 'bot.env');
-      const repoPath = join(import.meta.dir, '..', 'bots', name, 'bot.env');
+      const repoPath = join(import.meta.dir, '..', '..', 'bots', name, 'bot.env');
       const envPath = existsSync(cwdPath) ? cwdPath : repoPath;
 
       if (!existsSync(envPath)) {
@@ -82,7 +110,6 @@ class BotManager {
     console.error(`[MCP] Connecting bot "${name}":`);
     console.error(`[MCP]   username: ${username}`);
     console.error(`[MCP]   gateway: ${gateway}`);
-    console.error(`[MCP]   password: ${pwd ? pwd.substring(0, 3) + '...' : 'MISSING'}`);
 
     const sdk = new BotSDK({
       botUsername: username,
@@ -124,6 +151,57 @@ class BotManager {
     return connection;
   }
 
+  /**
+   * Return a usable cached connection, reconnecting a dead transport and, for
+   * mutating tools, refreshing a stale browser session. Throws an actionable
+   * error rather than letting an operation run against old state.
+   */
+  async ensureHealthy(name: string, options: EnsureHealthyOptions = {}): Promise<BotConnection> {
+    const {
+      requireFreshState = true,
+      maxStateAgeMs = 15_000,
+      readyTimeoutMs = 15_000,
+    } = options;
+
+    let connection = this.get(name);
+    if (!connection) {
+      connection = await this.connect(name);
+    } else if (!connection.sdk.isConnected() || !connection.sdk.isAuthenticated()) {
+      connection.connected = false;
+      await this.connectWithRetry(connection.sdk);
+      connection.connected = true;
+    }
+
+    if (!requireFreshState) return connection;
+    if (this.hasFreshState(connection, maxStateAgeMs)) return connection;
+
+    // Refresh even when gateway diagnostics say the browser is active: stale
+    // local state can mean this SDK socket stopped receiving updates. For a
+    // stale/dead browser, reconnecting also re-runs BotSDK's auto-launch policy.
+    await connection.sdk.checkBotStatus();
+    await connection.sdk.disconnect();
+    connection.connected = false;
+    await this.connectWithRetry(connection.sdk);
+    connection.connected = true;
+
+    try {
+      await connection.sdk.waitForCondition(
+        () => this.hasFreshState(connection!, maxStateAgeMs),
+        readyTimeoutMs,
+      );
+    } catch {
+      const latestStatus = await connection.sdk.checkBotStatus();
+      throw new Error(this.formatUnhealthyMessage(name, connection, latestStatus, maxStateAgeMs));
+    }
+
+    if (!this.hasFreshState(connection, maxStateAgeMs)) {
+      const latestStatus = await connection.sdk.checkBotStatus();
+      throw new Error(this.formatUnhealthyMessage(name, connection, latestStatus, maxStateAgeMs));
+    }
+
+    return connection;
+  }
+
   private async connectWithRetry(sdk: BotSDK, maxAttempts = 3, timeoutMs = 30000): Promise<void> {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       try {
@@ -160,7 +238,7 @@ class BotManager {
     if (connection.unsubscribeConnectionState) {
       connection.unsubscribeConnectionState();
     }
-    connection.sdk.disconnect();
+    await connection.sdk.disconnect();
     connection.connected = false;
     this.connections.delete(name);
     console.error(`[MCP] Bot "${name}" disconnected`);
@@ -176,11 +254,43 @@ class BotManager {
   /**
    * List all connected bots
    */
-  list(): Array<{ name: string; username: string; connected: boolean }> {
-    return Array.from(this.connections.entries()).map(([name, conn]) => ({
-      name,
-      username: conn.username,
-      connected: conn.connected
+  async list(): Promise<BotConnectionSummary[]> {
+    return Promise.all(Array.from(this.connections.entries()).map(async ([name, conn]) => {
+      let status: BotStatus | null = null;
+      try {
+        status = await conn.sdk.checkBotStatus();
+      } catch {
+        // Local connection details remain useful if gateway diagnostics fail.
+      }
+
+      const state = conn.sdk.getState();
+      const stateAge = state && conn.sdk.getStateReceivedAt() > 0
+        ? conn.sdk.getStateAge()
+        : null;
+
+      return {
+        name,
+        username: conn.username,
+        connected: conn.sdk.isConnected(),
+        authenticated: conn.sdk.isAuthenticated(),
+        connectionState: conn.sdk.getConnectionState(),
+        connectionMode: conn.sdk.getConnectionMode(),
+        reconnectAttempt: conn.sdk.getReconnectAttempt(),
+        hasState: state !== null,
+        stateAgeMs: stateAge,
+        inGame: state?.inGame ?? status?.inGame ?? null,
+        tick: state?.tick ?? null,
+        player: state?.player
+          ? {
+              name: state.player.name,
+              worldX: state.player.worldX,
+              worldZ: state.player.worldZ,
+            }
+          : status?.player ?? null,
+        sessionStatus: status?.status ?? 'unknown',
+        controllers: status?.controllers ?? [],
+        observers: status?.observers ?? [],
+      };
     }));
   }
 
@@ -202,6 +312,26 @@ class BotManager {
       }
     }
     return result;
+  }
+
+  private hasFreshState(connection: BotConnection, maxStateAgeMs: number): boolean {
+    return connection.sdk.getState() !== null
+      && connection.sdk.getStateReceivedAt() > 0
+      && connection.sdk.getStateAge() <= maxStateAgeMs;
+  }
+
+  private formatUnhealthyMessage(
+    name: string,
+    connection: BotConnection,
+    status: BotStatus,
+    maxStateAgeMs: number,
+  ): string {
+    const localAge = connection.sdk.getStateReceivedAt() > 0
+      ? `${connection.sdk.getStateAge()}ms`
+      : 'never received';
+    const remoteAge = status.stateAge === null ? 'never received' : `${status.stateAge}ms`;
+    return `Bot "${name}" has no fresh game state (local: ${localAge}, gateway: ${status.status}/${remoteAge}, required <= ${maxStateAgeMs}ms). `
+      + 'Open or reload the bot browser, confirm the character is logged in, then retry.';
   }
 }
 

--- a/mcp/api/index.ts
+++ b/mcp/api/index.ts
@@ -15,11 +15,11 @@ export interface BotConnection {
   connected: boolean;
   unsubscribeConnectionState?: () => void;
   /**
-   * High-water tick for gameMessages already shown to the agent. Used by
-   * the MCP server's formatter so repeated execute_code calls only render
-   * NEW chat / system messages. Internal — not part of the SDK surface.
+   * High-water cursor for gameMessages already shown to the agent. Prefers
+   * observationId when available and falls back to tick for older clients.
+   * Internal — not part of the SDK surface.
    */
-  lastShownMessageTick: number;
+  lastShownMessageCursor: number;
 }
 
 export interface BotConnectionSummary {
@@ -133,7 +133,7 @@ export class BotManager {
       bot,
       username,
       connected: true,
-      lastShownMessageTick: -1
+      lastShownMessageCursor: -1
     };
 
     // Track connection state changes

--- a/mcp/execution.test.ts
+++ b/mcp/execution.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  BoundedLogBuffer,
+  executeUserCode,
+  holdQueueUntil,
+  PerBotExecutionQueue,
+  runCancellableOperation,
+  transpileTypeScriptBody,
+} from './execution';
+import type { BotActions } from '../sdk/actions';
+import type { BotSDK } from '../sdk';
+
+function fakeTargets(sdk: Record<string, unknown> = {}, bot: Record<string, unknown> = {}) {
+  return {
+    sdk: sdk as unknown as BotSDK,
+    bot: bot as unknown as BotActions,
+  };
+}
+
+describe('TypeScript execution', () => {
+  test('transpiles TypeScript-only syntax in an async function body', async () => {
+    const targets = fakeTargets();
+    const outcome = await executeUserCode({
+      ...targets,
+      code: `
+        const count: number = 2;
+        const maybe: { value: number } | null = { value: 3 };
+        console.log("sum", count + maybe!.value);
+        return count + maybe!.value;
+      `,
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome.status).toBe('success');
+    expect(outcome.result).toBe(5);
+    expect(outcome.logs).toEqual(['sum 5']);
+  });
+
+  test('returns useful TypeScript compilation errors', () => {
+    expect(() => transpileTypeScriptBody('const broken: = 1;'))
+      .toThrow('TypeScript compilation failed');
+  });
+
+  test('preserves request logs when user code throws', async () => {
+    const outcome = await executeUserCode({
+      ...fakeTargets(),
+      code: 'console.warn("before failure"); throw new Error("boom");',
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.error).toBe('boom');
+    expect(outcome.logs).toEqual(['[warn] before failure']);
+  });
+
+  test('classifies timeouts separately from cancellation', async () => {
+    const outcome = await executeUserCode({
+      ...fakeTargets(),
+      code: 'await new Promise(() => {});',
+      timeoutMs: 10,
+    });
+
+    expect(outcome.status).toBe('timeout');
+    expect(outcome.error).toContain('timed out');
+  });
+
+  test('blocks follow-up calls and exposes quiescence after cancellation', async () => {
+    const calls: string[] = [];
+    const controller = new AbortController();
+    const targets = fakeTargets({
+      first: async () => {
+        calls.push('first:start');
+        await Bun.sleep(40);
+        calls.push('first:end');
+      },
+      second: async () => {
+        calls.push('second');
+      },
+    });
+
+    setTimeout(() => controller.abort('test cancellation'), 5);
+    const outcome = await executeUserCode({
+      ...targets,
+      code: 'await (sdk as any).first(); await (sdk as any).second();',
+      timeoutMs: 1_000,
+      externalSignal: controller.signal,
+    });
+
+    expect(outcome.status).toBe('cancelled');
+    expect(outcome.mayHaveInFlightCall).toBe(true);
+    expect(calls).toEqual(['first:start']);
+    await outcome.quiescence;
+    expect(calls).toEqual(['first:start', 'first:end']);
+  });
+
+  test('drains an unawaited SDK promise before successful completion', async () => {
+    let settled = false;
+    const targets = fakeTargets({
+      delayed: async () => {
+        await Bun.sleep(20);
+        settled = true;
+      },
+    });
+
+    const outcome = await executeUserCode({
+      ...targets,
+      code: '(sdk as any).delayed(); return "done";',
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome.status).toBe('success');
+    expect(outcome.result).toBe('done');
+    expect(settled).toBe(true);
+  });
+});
+
+describe('bounded request-scoped logs', () => {
+  test('caps entries and reports truncation', () => {
+    const logs = new BoundedLogBuffer(12, 2);
+    logs.append('log', ['123456']);
+    logs.append('warn', ['abcdef']);
+    logs.append('log', ['ignored']);
+
+    expect(logs.truncated).toBe(true);
+    expect(logs.toArray().at(-1)).toContain('logs truncated');
+    expect(logs.toArray().length).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('per-bot execution queue', () => {
+  test('serializes one bot but allows different bots concurrently', async () => {
+    const queue = new PerBotExecutionQueue();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+    const first = queue.run('alpha', async () => {
+      events.push('alpha:first:start');
+      await firstGate;
+      events.push('alpha:first:end');
+      return 1;
+    });
+    const second = queue.run('alpha', async () => {
+      events.push('alpha:second');
+      return 2;
+    });
+    const other = queue.run('beta', async () => {
+      events.push('beta');
+      return 3;
+    });
+
+    await other;
+    expect(events).toEqual(['alpha:first:start', 'beta']);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['alpha:first:start', 'beta', 'alpha:first:end', 'alpha:second']);
+  });
+
+  test('holds the lock after returning a timeout result until quiescent', async () => {
+    const queue = new PerBotExecutionQueue();
+    const events: string[] = [];
+    let releaseCall!: () => void;
+    const inFlight = new Promise<void>(resolve => { releaseCall = resolve; });
+
+    const first = queue.run('alpha', async () =>
+      holdQueueUntil('timeout response', inFlight));
+    expect(await first).toBe('timeout response');
+    expect(queue.isLocked('alpha')).toBe(true);
+
+    const second = queue.run('alpha', async () => {
+      events.push('second');
+      return 'done';
+    });
+    await Bun.sleep(5);
+    expect(events).toEqual([]);
+
+    releaseCall();
+    expect(await second).toBe('done');
+    expect(queue.isLocked('alpha')).toBe(false);
+  });
+});
+
+describe('structured operation cancellation', () => {
+  test('returns cancellation promptly and exposes operation quiescence', async () => {
+    const controller = new AbortController();
+    let completed = false;
+    const outcomePromise = runCancellableOperation(async () => {
+      await Bun.sleep(30);
+      completed = true;
+      return 42;
+    }, controller.signal);
+
+    setTimeout(() => controller.abort('stop action'), 5);
+    const outcome = await outcomePromise;
+    expect(outcome.status).toBe('cancelled');
+    expect(completed).toBe(false);
+    await outcome.quiescence;
+    expect(completed).toBe(true);
+  });
+});

--- a/mcp/execution.ts
+++ b/mcp/execution.ts
@@ -1,0 +1,453 @@
+import type { BotActions } from '../sdk/actions';
+import type { BotSDK } from '../sdk/index';
+import { inspect } from 'node:util';
+
+const DEFAULT_LOG_LIMIT = 64 * 1024;
+const DEFAULT_LOG_ENTRIES = 500;
+
+export type ExecutionStatus = 'success' | 'error' | 'timeout' | 'cancelled';
+
+export interface ExecutionOutcome {
+  status: ExecutionStatus;
+  result?: unknown;
+  error?: string;
+  logs: string[];
+  logsTruncated: boolean;
+  elapsedMs: number;
+  /**
+   * True when cancellation happened while an SDK/BotActions promise was
+   * already running. The public SDK does not currently accept AbortSignal, so
+   * that call may still finish. The proxy refuses new user calls and the queue
+   * remains locked while an already-started BotActions method finishes any
+   * internal SDK work.
+   */
+  mayHaveInFlightCall: boolean;
+  /**
+   * Resolves after calls that were already in progress have settled. The MCP
+   * queue uses this to keep the bot locked after returning a timeout response.
+   */
+  quiescence?: Promise<void>;
+}
+
+export class BoundedLogBuffer {
+  private readonly entries: string[] = [];
+  private size = 0;
+  private omitted = 0;
+
+  constructor(
+    private readonly maxChars = DEFAULT_LOG_LIMIT,
+    private readonly maxEntries = DEFAULT_LOG_ENTRIES,
+  ) {}
+
+  append(level: string, args: unknown[]): void {
+    const prefix = level === 'log' ? '' : `[${level}] `;
+    const rendered = prefix + args.map(formatLogArgument).join(' ');
+    const remaining = this.maxChars - this.size;
+
+    if (this.entries.length >= this.maxEntries || remaining <= 0) {
+      this.omitted++;
+      return;
+    }
+
+    const entry = rendered.length <= remaining
+      ? rendered
+      : rendered.slice(0, Math.max(0, remaining - 1)) + '…';
+    this.entries.push(entry);
+    this.size += entry.length;
+    if (entry.length < rendered.length) this.omitted++;
+  }
+
+  toArray(): string[] {
+    if (this.omitted === 0) return [...this.entries];
+    return [...this.entries, `[logs truncated: ${this.omitted} entr${this.omitted === 1 ? 'y' : 'ies'} omitted]`];
+  }
+
+  get truncated(): boolean {
+    return this.omitted > 0;
+  }
+}
+
+export function createScopedConsole(buffer: BoundedLogBuffer): Console {
+  const capture = (level: string) => (...args: unknown[]) => buffer.append(level, args);
+  return {
+    log: capture('log'),
+    info: capture('info'),
+    debug: capture('debug'),
+    warn: capture('warn'),
+    error: capture('error'),
+    trace: capture('trace'),
+    dir: capture('dir'),
+    dirxml: capture('dirxml'),
+    table: capture('table'),
+    group: capture('group'),
+    groupCollapsed: capture('groupCollapsed'),
+    groupEnd: () => {},
+    clear: () => {},
+    count: capture('count'),
+    countReset: capture('countReset'),
+    assert: (condition?: boolean, ...data: unknown[]) => {
+      if (!condition) buffer.append('assert', data);
+    },
+    profile: () => {},
+    profileEnd: () => {},
+    time: () => {},
+    timeEnd: capture('timeEnd'),
+    timeLog: capture('timeLog'),
+    timeStamp: () => {},
+    Console: console.Console,
+  } as Console;
+}
+
+/**
+ * Compile a TypeScript function body to JavaScript while preserving top-level
+ * await/return semantics by compiling it inside an async function.
+ */
+export function transpileTypeScriptBody(code: string): string {
+  const wrapperName = '__rsAgentExecute';
+  const wrapped = `
+async function ${wrapperName}(
+  bot: import("../sdk/actions").BotActions,
+  sdk: import("../sdk/index").BotSDK,
+  console: Console,
+  signal: AbortSignal
+) {
+${code}
+}
+`;
+
+  try {
+    const transpiler = new Bun.Transpiler({
+      loader: 'ts',
+      target: 'bun',
+      trimUnusedImports: true,
+    });
+    return `${transpiler.transformSync(wrapped)}\nreturn await ${wrapperName}(bot, sdk, console, signal);`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`TypeScript compilation failed: ${message}`);
+  }
+}
+
+export interface ExecuteUserCodeOptions {
+  bot: BotActions;
+  sdk: BotSDK;
+  code: string;
+  timeoutMs: number;
+  externalSignal?: AbortSignal;
+  logLimitChars?: number;
+  logLimitEntries?: number;
+}
+
+export interface CancellableOperationOutcome<T> {
+  status: 'success' | 'cancelled' | 'error';
+  value?: T;
+  error?: string;
+  quiescence?: Promise<void>;
+}
+
+/**
+ * Race one structured operation against MCP cancellation. The public SDK
+ * cannot interrupt a BotActions promise after it starts, so cancellation
+ * returns promptly while exposing quiescence for the per-bot lock.
+ */
+export async function runCancellableOperation<T>(
+  operation: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<CancellableOperationOutcome<T>> {
+  if (signal?.aborted) {
+    return {
+      status: 'cancelled',
+      error: typeof signal.reason === 'string' ? signal.reason : 'Operation cancelled',
+    };
+  }
+
+  const running = Promise.resolve().then(operation);
+  running.catch(() => {});
+  let onAbort: (() => void) | undefined;
+  const cancellation = new Promise<never>((_, reject) => {
+    if (!signal) return;
+    onAbort = () => reject(new OperationCancelledError(
+      typeof signal.reason === 'string' ? signal.reason : 'Operation cancelled',
+    ));
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+  try {
+    return { status: 'success', value: await Promise.race([running, cancellation]) };
+  } catch (error) {
+    if (error instanceof OperationCancelledError) {
+      return {
+        status: 'cancelled',
+        error: error.message,
+        quiescence: running.then(() => {}, () => {}),
+      };
+    }
+    return {
+      status: 'error',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+  }
+}
+
+export async function executeUserCode(options: ExecuteUserCodeOptions): Promise<ExecutionOutcome> {
+  const startedAt = Date.now();
+  const logs = new BoundedLogBuffer(options.logLimitChars, options.logLimitEntries);
+  const scopedConsole = createScopedConsole(logs);
+  const controller = new AbortController();
+  const signal = controller.signal;
+  const inFlight = new Set<Promise<unknown>>();
+  let acceptingCalls = true;
+
+  const stop = (reason: unknown) => {
+    acceptingCalls = false;
+    if (!signal.aborted) controller.abort(reason);
+  };
+
+  const externalAbort = () => stop(options.externalSignal?.reason ?? 'Cancelled by MCP client');
+  if (options.externalSignal?.aborted) externalAbort();
+  else options.externalSignal?.addEventListener('abort', externalAbort, { once: true });
+
+  const cancellable = <T extends object>(target: T): T =>
+    new Proxy(target, {
+      get(obj, prop, receiver) {
+        const value = Reflect.get(obj, prop, receiver);
+        if (typeof value !== 'function') return value;
+
+        return (...args: unknown[]) => {
+          if (!acceptingCalls || signal.aborted) {
+            throw new Error(`Execution cancelled; refusing ${String(prop)}()`);
+          }
+
+          const result = Reflect.apply(value, obj, args);
+          if (!isPromiseLike(result)) return result;
+
+          const tracked = Promise.resolve(result);
+          inFlight.add(tracked);
+          tracked.finally(() => inFlight.delete(tracked)).catch(() => {});
+          return tracked;
+        };
+      },
+    });
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    if (signal.aborted) {
+      return {
+        status: 'cancelled',
+        error: typeof signal.reason === 'string' ? signal.reason : 'Code execution cancelled',
+        logs: logs.toArray(),
+        logsTruncated: logs.truncated,
+        elapsedMs: Date.now() - startedAt,
+        mayHaveInFlightCall: false,
+      };
+    }
+
+    const javascript = transpileTypeScriptBody(options.code);
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const fn = new AsyncFunction('bot', 'sdk', 'console', 'signal', javascript);
+
+    const invocation = (async () => {
+      const result = await fn(
+        cancellable(options.bot),
+        cancellable(options.sdk),
+        scopedConsole,
+        signal,
+      );
+
+      // Once the user's main function returns, refuse timer/callback-driven
+      // follow-up actions, but wait for promises it already started. This
+      // prevents ordinary fire-and-forget calls from leaking into the next run.
+      acceptingCalls = false;
+      while (inFlight.size > 0) {
+        await Promise.allSettled([...inFlight]);
+      }
+      return result;
+    })();
+    invocation.catch(() => {});
+
+    const terminal = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        const timeoutError = new ExecutionTerminalError(
+          'timeout',
+          `Code execution timed out after ${formatDuration(options.timeoutMs)}`,
+        );
+        // Abort listeners run synchronously. Using the typed terminal error as
+        // the abort reason preserves timeout (rather than cancellation) status.
+        stop(timeoutError);
+        reject(timeoutError);
+      }, options.timeoutMs);
+
+      signal.addEventListener('abort', () => {
+        const reason = signal.reason;
+        if (reason instanceof ExecutionTerminalError) {
+          reject(reason);
+          return;
+        }
+        const message = typeof reason === 'string' ? reason : 'Code execution cancelled';
+        reject(new ExecutionTerminalError('cancelled', message));
+      }, { once: true });
+    });
+
+    const result = await Promise.race([invocation, terminal]);
+    acceptingCalls = false;
+    return {
+      status: 'success',
+      result,
+      logs: logs.toArray(),
+      logsTruncated: logs.truncated,
+      elapsedMs: Date.now() - startedAt,
+      mayHaveInFlightCall: false,
+    };
+  } catch (error) {
+    const status = error instanceof ExecutionTerminalError ? error.status : 'error';
+    const pendingCalls = [...inFlight];
+    return {
+      status,
+      error: error instanceof Error ? error.message : String(error),
+      logs: logs.toArray(),
+      logsTruncated: logs.truncated,
+      elapsedMs: Date.now() - startedAt,
+      mayHaveInFlightCall: pendingCalls.length > 0,
+      quiescence: pendingCalls.length > 0
+        ? Promise.allSettled(pendingCalls).then(() => {})
+        : undefined,
+    };
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    acceptingCalls = false;
+    options.externalSignal?.removeEventListener('abort', externalAbort);
+  }
+}
+
+class ExecutionTerminalError extends Error {
+  constructor(readonly status: 'timeout' | 'cancelled', message: string) {
+    super(message);
+  }
+}
+
+class OperationCancelledError extends Error {}
+
+export class PerBotExecutionQueue {
+  private readonly locked = new Set<string>();
+  private readonly waiters = new Map<string, Array<{
+    resolve: (release: () => void) => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort?: () => void;
+  }>>();
+
+  isLocked(botName: string): boolean {
+    return this.locked.has(botName);
+  }
+
+  async run<T>(
+    botName: string,
+    task: () => Promise<T | QueueHeldResult<T>>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const release = await this.acquire(botName, signal);
+    let releaseDeferred = false;
+    try {
+      const result = await task();
+      if (result instanceof QueueHeldResult) {
+        releaseDeferred = true;
+        result.until.finally(release).catch(() => {});
+        return result.value;
+      }
+      return result;
+    } finally {
+      if (!releaseDeferred) release();
+    }
+  }
+
+  private acquire(botName: string, signal?: AbortSignal): Promise<() => void> {
+    if (signal?.aborted) {
+      return Promise.reject(new Error('Cancelled while waiting for the bot execution lock'));
+    }
+
+    if (!this.locked.has(botName)) {
+      this.locked.add(botName);
+      return Promise.resolve(this.createRelease(botName));
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter: {
+        resolve: (release: () => void) => void;
+        reject: (error: Error) => void;
+        signal?: AbortSignal;
+        onAbort?: () => void;
+      } = { resolve, reject, signal };
+
+      if (signal) {
+        waiter.onAbort = () => {
+          const queue = this.waiters.get(botName);
+          if (queue) {
+            const index = queue.indexOf(waiter);
+            if (index >= 0) queue.splice(index, 1);
+          }
+          reject(new Error('Cancelled while waiting for the bot execution lock'));
+        };
+        signal.addEventListener('abort', waiter.onAbort, { once: true });
+      }
+
+      const queue = this.waiters.get(botName) ?? [];
+      queue.push(waiter);
+      this.waiters.set(botName, queue);
+    });
+  }
+
+  private createRelease(botName: string): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+
+      const queue = this.waiters.get(botName);
+      while (queue && queue.length > 0) {
+        const next = queue.shift()!;
+        if (next.signal?.aborted) continue;
+        if (next.signal && next.onAbort) {
+          next.signal.removeEventListener('abort', next.onAbort);
+        }
+        next.resolve(this.createRelease(botName));
+        if (queue.length === 0) this.waiters.delete(botName);
+        return;
+      }
+
+      this.waiters.delete(botName);
+      this.locked.delete(botName);
+    };
+  }
+}
+
+export class QueueHeldResult<T> {
+  constructor(readonly value: T, readonly until: Promise<unknown>) {}
+}
+
+export function holdQueueUntil<T>(value: T, until: Promise<unknown>): QueueHeldResult<T> {
+  return new QueueHeldResult(value, until);
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return typeof value === 'object' && value !== null && 'then' in value
+    && typeof (value as { then?: unknown }).then === 'function';
+}
+
+function formatLogArgument(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return value.stack ?? value.message;
+  return inspect(value, {
+    depth: 5,
+    maxArrayLength: 100,
+    maxStringLength: 4_096,
+    breakLength: 120,
+    compact: 3,
+  });
+}
+
+function formatDuration(ms: number): string {
+  if (ms >= 60_000 && ms % 60_000 === 0) return `${ms / 60_000} minute(s)`;
+  return `${ms}ms`;
+}

--- a/mcp/output.test.ts
+++ b/mcp/output.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import { buildExecutionOutput, jsonResponseText } from './output';
+import type { BotConnection } from './api';
+
+function connectionWithState(): BotConnection {
+  const state = {
+    tick: 100,
+    inGame: true,
+    player: {
+      name: 'tester',
+      combatLevel: 3,
+      hp: 10,
+      maxHp: 10,
+      worldX: 3200,
+      worldZ: 3200,
+      level: 0,
+      combat: { inCombat: false, targetIndex: -1, lastDamageTick: -1 },
+    },
+    modalOpen: false,
+    modalInterface: -1,
+    dialog: { isOpen: false, isWaiting: false, options: [] },
+    interface: { isOpen: false, interfaceId: -1, options: [] },
+    shop: { isOpen: false },
+    bank: { isOpen: false },
+    skills: [],
+    inventory: [],
+    equipment: [],
+    nearbyNpcs: [],
+    nearbyPlayers: [],
+    nearbyLocs: [],
+    groundItems: [],
+    gameMessages: [{ type: 0, text: 'terminal snapshot', sender: '', tick: 100, fromSelf: false }],
+    combatEvents: [],
+  };
+  return {
+    sdk: {
+      getState: () => state,
+      getStateAge: () => 25,
+    },
+    bot: {},
+    username: 'tester',
+    connected: true,
+    lastShownMessageTick: -1,
+  } as unknown as BotConnection;
+}
+
+describe('bounded MCP output', () => {
+  test('error output preserves partial logs and a terminal state snapshot', () => {
+    const output = buildExecutionOutput({
+      status: 'error',
+      error: 'boom',
+      logs: ['before failure'],
+      logsTruncated: false,
+      elapsedMs: 12,
+      mayHaveInFlightCall: false,
+    }, connectionWithState(), false);
+
+    expect(output).toContain('before failure');
+    expect(output).toContain('boom');
+    expect(output).toContain('── Terminal World State ──');
+    expect(output).toContain('terminal snapshot');
+  });
+
+  test('caps structured JSON responses', () => {
+    const output = jsonResponseText({ value: 'x'.repeat(1_000) }, 100);
+    expect(output.length).toBeLessThanOrEqual(100);
+    expect(output).toContain('truncated');
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+});

--- a/mcp/output.test.ts
+++ b/mcp/output.test.ts
@@ -40,7 +40,7 @@ function connectionWithState(): BotConnection {
     bot: {},
     username: 'tester',
     connected: true,
-    lastShownMessageTick: -1,
+    lastShownMessageCursor: -1,
   } as unknown as BotConnection;
 }
 
@@ -66,5 +66,42 @@ describe('bounded MCP output', () => {
     expect(output.length).toBeLessThanOrEqual(100);
     expect(output).toContain('truncated');
     expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  test('uses observation ids to show messages that share a public tick', () => {
+    const connection = connectionWithState();
+    const state = connection.sdk.getState()!;
+    const messages = state.gameMessages as Array<
+      (typeof state.gameMessages)[number] & { observationId?: number }
+    >;
+    messages[0]!.observationId = 1;
+
+    const first = buildExecutionOutput({
+      status: 'success',
+      logs: [],
+      logsTruncated: false,
+      elapsedMs: 1,
+      mayHaveInFlightCall: false,
+    }, connection, false);
+
+    messages.push({
+      type: 0,
+      text: 'same tick, later observation',
+      sender: '',
+      tick: 100,
+      observationId: 2,
+      fromSelf: false,
+    });
+    const second = buildExecutionOutput({
+      status: 'success',
+      logs: [],
+      logsTruncated: false,
+      elapsedMs: 1,
+      mayHaveInFlightCall: false,
+    }, connection, false);
+
+    expect(first).toContain('terminal snapshot');
+    expect(second).not.toContain('terminal snapshot');
+    expect(second).toContain('same tick, later observation');
   });
 });

--- a/mcp/output.ts
+++ b/mcp/output.ts
@@ -57,12 +57,16 @@ export function buildExecutionOutput(
 
   const state = connection.sdk.getState();
   if (state) {
-    const sinceTick = updateMessageCursor(connection);
+    const sinceCursor = updateMessageCursor(connection, state.gameMessages ?? []);
+    const terminalState = {
+      ...state,
+      gameMessages: (state.gameMessages ?? []).filter(
+        message => getMessageCursor(message) > sinceCursor,
+      ),
+    };
     parts.push('── Terminal World State ──');
     parts.push(truncateText(
-      formatWorldState(state, connection.sdk.getStateAge(), {
-        sinceTick,
-      }),
+      formatWorldState(terminalState, connection.sdk.getStateAge()),
       MAX_STATE_CHARS,
       'world state',
     ));
@@ -101,19 +105,34 @@ export function truncateText(text: string, maxChars: number, label: string): str
   return text.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
 }
 
-function updateMessageCursor(connection: BotConnection): number {
-  const state = connection.sdk.getState();
-  if (!state) return connection.lastShownMessageTick;
+type CursorBearingMessage = {
+  tick: number;
+  observationId?: unknown;
+};
 
-  if (state.gameMessages?.length > 0
-      && state.gameMessages.every(message => message.tick < connection.lastShownMessageTick)) {
-    connection.lastShownMessageTick = -1;
+function getMessageCursor(message: { tick: number }): number {
+  const observationId = (message as CursorBearingMessage).observationId;
+  return typeof observationId === 'number' && Number.isFinite(observationId)
+    ? observationId
+    : message.tick;
+}
+
+function updateMessageCursor(
+  connection: BotConnection,
+  messages: readonly { tick: number }[],
+): number {
+  if (messages.length > 0
+      && messages.every(
+        message => getMessageCursor(message) < connection.lastShownMessageCursor,
+      )) {
+    connection.lastShownMessageCursor = -1;
   }
-  const sinceTick = connection.lastShownMessageTick;
-  for (const message of state.gameMessages ?? []) {
-    if (message.tick > connection.lastShownMessageTick) {
-      connection.lastShownMessageTick = message.tick;
+  const sinceCursor = connection.lastShownMessageCursor;
+  for (const message of messages) {
+    const messageCursor = getMessageCursor(message);
+    if (messageCursor > connection.lastShownMessageCursor) {
+      connection.lastShownMessageCursor = messageCursor;
     }
   }
-  return sinceTick;
+  return sinceCursor;
 }

--- a/mcp/output.ts
+++ b/mcp/output.ts
@@ -1,0 +1,119 @@
+import type { BotConnection } from './api';
+import type { ExecutionOutcome } from './execution';
+import { formatWorldState } from '../sdk/formatter';
+
+export const MAX_TOOL_OUTPUT_CHARS = 160 * 1024;
+const MAX_RESULT_CHARS = 32 * 1024;
+const MAX_STATE_CHARS = 48 * 1024;
+
+export function jsonResponseText(value: unknown, maxChars = MAX_TOOL_OUTPUT_CHARS): string {
+  const serialized = safeStringify(value);
+  if (serialized.length <= maxChars) return serialized;
+
+  // Keep structured-tool responses valid JSON even when bounded. Agents can
+  // request narrower inspect_state sections instead of receiving a broken JSON
+  // fragment.
+  let previewLength = Math.max(0, Math.floor(maxChars * 0.7));
+  let bounded = '';
+  do {
+    bounded = safeStringify({
+      truncated: true,
+      originalChars: serialized.length,
+      omittedChars: serialized.length - previewLength,
+      message: 'Response exceeded the MCP output limit. Request fewer state sections or narrower query filters.',
+      preview: serialized.slice(0, previewLength),
+    });
+    previewLength = Math.max(0, previewLength - Math.max(1, bounded.length - maxChars));
+  } while (bounded.length > maxChars && previewLength > 0);
+
+  return bounded.length <= maxChars
+    ? bounded
+    : '{"truncated":true,"message":"Response exceeded the MCP output limit."}';
+}
+
+export function buildExecutionOutput(
+  outcome: ExecutionOutcome,
+  connection: BotConnection,
+  isLongCode: boolean,
+): string {
+  const parts: string[] = [];
+
+  parts.push(`── Execution (${outcome.status}, ${outcome.elapsedMs}ms) ──`);
+  if (outcome.logs.length > 0) {
+    parts.push('── Console ──');
+    parts.push(outcome.logs.join('\n'));
+  }
+
+  if (outcome.status === 'success' && outcome.result !== undefined) {
+    parts.push('── Result ──');
+    parts.push(truncateText(safeStringify(outcome.result), MAX_RESULT_CHARS, 'result'));
+  } else if (outcome.status !== 'success') {
+    parts.push('── Error ──');
+    parts.push(outcome.error ?? 'Execution failed');
+    if (outcome.mayHaveInFlightCall) {
+      parts.push('An SDK/BotActions call had already started when execution stopped. The public SDK cannot abort it; new calls through this execution’s bot/sdk proxies are refused and the bot queue stays locked until the started call settles.');
+    }
+  }
+
+  const state = connection.sdk.getState();
+  if (state) {
+    const sinceTick = updateMessageCursor(connection);
+    parts.push('── Terminal World State ──');
+    parts.push(truncateText(
+      formatWorldState(state, connection.sdk.getStateAge(), {
+        sinceTick,
+      }),
+      MAX_STATE_CHARS,
+      'world state',
+    ));
+  } else {
+    parts.push('── Terminal World State ──');
+    parts.push('(no game state received)');
+  }
+
+  if (isLongCode) {
+    parts.push('── Tip ──');
+    parts.push('Long script detected. For persistent jobs, write a bot script and run it through sdk/runner.ts so process lifecycle and output are explicit.');
+  }
+
+  return truncateText(parts.join('\n\n'), MAX_TOOL_OUTPUT_CHARS, 'tool output');
+}
+
+export function safeStringify(value: unknown): string {
+  const seen = new WeakSet<object>();
+  try {
+    return JSON.stringify(value, (_key, nested) => {
+      if (typeof nested === 'bigint') return `${nested}n`;
+      if (typeof nested === 'object' && nested !== null) {
+        if (seen.has(nested)) return '[Circular]';
+        seen.add(nested);
+      }
+      return nested;
+    }, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export function truncateText(text: string, maxChars: number, label: string): string {
+  if (text.length <= maxChars) return text;
+  const suffix = `\n[${label} truncated: ${text.length - maxChars} characters omitted]`;
+  return text.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
+}
+
+function updateMessageCursor(connection: BotConnection): number {
+  const state = connection.sdk.getState();
+  if (!state) return connection.lastShownMessageTick;
+
+  if (state.gameMessages?.length > 0
+      && state.gameMessages.every(message => message.tick < connection.lastShownMessageTick)) {
+    connection.lastShownMessageTick = -1;
+  }
+  const sinceTick = connection.lastShownMessageTick;
+  for (const message of state.gameMessages ?? []) {
+    if (message.tick > connection.lastShownMessageTick) {
+      connection.lastShownMessageTick = message.tick;
+    }
+  }
+  return sinceTick;
+}

--- a/mcp/resources.test.ts
+++ b/mcp/resources.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { SDK_API_RESOURCE_URI, getResourceDefinitions, readAllowedResource } from './resources';
+
+describe('MCP resources', () => {
+  test('reads the advertised API resource', async () => {
+    const resources = getResourceDefinitions();
+    expect(resources.map(resource => resource.uri)).toEqual([SDK_API_RESOURCE_URI]);
+    const content = await readAllowedResource(SDK_API_RESOURCE_URI);
+    expect(content.text).toContain('# SDK API Reference');
+    expect(content.mimeType).toBe('text/markdown');
+  });
+
+  test('rejects traversal and arbitrary absolute files', async () => {
+    await expect(readAllowedResource('file://../../../../etc/passwd')).rejects.toThrow('Unknown resource URI');
+    await expect(readAllowedResource('file:///etc/passwd')).rejects.toThrow('Unknown resource URI');
+    await expect(readAllowedResource('https://example.com/API.md')).rejects.toThrow('Unknown resource URI');
+  });
+});

--- a/mcp/resources.ts
+++ b/mcp/resources.ts
@@ -1,0 +1,40 @@
+import { resolve } from 'path';
+
+export const SDK_API_RESOURCE_URI = 'file://../sdk/API.md';
+
+export interface ResourceDefinition {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+  filePath: string;
+}
+
+export function getResourceDefinitions(mcpDirectory = import.meta.dir): ResourceDefinition[] {
+  return [{
+    uri: SDK_API_RESOURCE_URI,
+    name: 'SDK API Reference',
+    description: 'Auto-generated reference for bot.* high-level actions and sdk.* low-level methods.',
+    mimeType: 'text/markdown',
+    filePath: resolve(mcpDirectory, '../sdk/API.md'),
+  }];
+}
+
+export async function readAllowedResource(uri: string, mcpDirectory = import.meta.dir): Promise<{
+  uri: string;
+  mimeType: string;
+  text: string;
+}> {
+  // Resource URIs are capabilities, not arbitrary local paths. Exact matching
+  // prevents ../ traversal and absolute file reads through the MCP endpoint.
+  const resource = getResourceDefinitions(mcpDirectory).find(candidate => candidate.uri === uri);
+  if (!resource) {
+    throw new Error(`Unknown resource URI: ${uri}`);
+  }
+
+  return {
+    uri: resource.uri,
+    mimeType: resource.mimeType,
+    text: await Bun.file(resource.filePath).text(),
+  };
+}

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -2,8 +2,9 @@
 /**
  * MCP Code Execution Server for RS-Agent
  *
- * Manages multiple bot connections dynamically at runtime.
- * Agents can connect, disconnect, and execute code on any connected bot.
+ * Security boundary: execute_code intentionally runs trusted agent-provided
+ * code in this Bun process. It is not a sandbox and can access process APIs,
+ * the filesystem, and the network with the MCP server's permissions.
  */
 
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -12,332 +13,250 @@ import {
   CallToolRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
-  ListToolsRequestSchema
+  ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
 import { botManager } from './api/index.js';
-import { formatWorldState } from '../sdk/formatter.js';
+import {
+  executeUserCode,
+  holdQueueUntil,
+  PerBotExecutionQueue,
+  runCancellableOperation,
+} from './execution.js';
+import { AGENT_TOOL_DEFINITIONS, inspectState, performAction, queryEntities } from './agent-tools.js';
+import { buildExecutionOutput, jsonResponseText } from './output.js';
+import { getResourceDefinitions, readAllowedResource } from './resources.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const executionQueue = new PerBotExecutionQueue();
 
-// Create MCP server
 const server = new Server(
   {
     name: 'rs-agent-bot',
-    version: '2.0.0'
+    version: '2.1.0',
   },
   {
     capabilities: {
       resources: {},
-      tools: {}
-    }
-  }
+      tools: {},
+    },
+  },
 );
 
-// List available API modules as resources
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
-  return {
-    resources: [
-      {
-        uri: 'file://../sdk/API.md',
-        name: 'SDK API Reference',
-        description: 'Auto-generated reference for bot.* (high-level actions: chopTree, walkTo, attackNpc, openBank, ...) and sdk.* (low-level: getState, sendWalk, findNearbyNpc, ...).',
-        mimeType: 'text/markdown'
-      }
-    ]
-  };
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+  resources: getResourceDefinitions().map(({ filePath: _filePath, ...resource }) => resource),
+}));
+
+server.setRequestHandler(ReadResourceRequestSchema, async request => {
+  const content = await readAllowedResource(request.params.uri);
+  return { contents: [content] };
 });
 
-// Read API module contents
-server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
-  try {
-    const uri = request.params.uri;
-    let filePath: string;
-
-    if (uri.startsWith('file://')) {
-      const relativePath = uri.replace('file://', '');
-      filePath = join(__dirname, relativePath);
-    } else {
-      throw new Error(`Unsupported URI scheme: ${uri}`);
-    }
-
-    const content = await Bun.file(filePath).text();
-
-    return {
-      contents: [
-        {
-          uri: request.params.uri,
-          mimeType: 'text/plain',
-          text: content
-        }
-      ]
-    };
-  } catch (error: any) {
-    throw new Error(`Failed to read resource: ${error.message}`);
-  }
-});
-
-// List available tools
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return {
-    tools: [
-      {
-        name: 'execute_code',
-        description: 'Execute TypeScript code on a bot. Auto-connects using credentials from bots/{name}/bot.env. The code runs in an async context with bot (BotActions) and sdk (BotSDK) available.',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            bot_name: {
-              type: 'string',
-              description: 'Bot name (matches folder in bots/). Auto-connects on first use.'
-            },
-            code: {
-              type: 'string',
-              description: 'TypeScript code to execute. Available globals: bot (BotActions), sdk (BotSDK). Example: "await bot.chopTree(); return sdk.getState();"'
-            },
-            timeout: {
-              type: 'number',
-              description: 'Execution timeout in minutes (default: 2, max: 60)'
-            }
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'execute_code',
+      description: 'Execute trusted TypeScript on a bot. Auto-connects using bots/{name}/bot.env. The async body receives bot (BotActions), sdk (BotSDK), console (request-scoped), and signal (AbortSignal). Calls are serialized per bot. This is not a security sandbox.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          bot_name: {
+            type: 'string',
+            description: 'Bot name (matches folder in bots/). Auto-connects on first use.',
           },
-          required: ['bot_name', 'code']
-        }
-      },
-      {
-        name: 'disconnect_bot',
-        description: 'Disconnect a connected bot',
-        inputSchema: {
-          type: 'object',
-          properties: {
-            name: {
-              type: 'string',
-              description: 'Bot name to disconnect'
-            }
+          code: {
+            type: 'string',
+            maxLength: 262144,
+            description: 'TypeScript async function body. Available globals: bot, sdk, console, signal.',
           },
-          required: ['name']
-        }
+          timeout: {
+            type: 'number',
+            minimum: 0.1,
+            maximum: 60,
+            description: 'Execution timeout in minutes (default: 2, max: 60).',
+          },
+        },
+        required: ['bot_name', 'code'],
+        additionalProperties: false,
       },
-      {
-        name: 'list_bots',
-        description: 'List all connected bots',
-        inputSchema: {
-          type: 'object',
-          properties: {}
-        }
-      }
-    ]
-  };
-});
+    },
+    ...AGENT_TOOL_DEFINITIONS,
+    {
+      name: 'disconnect_bot',
+      description: 'Disconnect a connected bot.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: { type: 'string', description: 'Bot name to disconnect.' },
+        },
+        required: ['name'],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: 'list_bots',
+      description: 'List bot sessions with transport/auth state, game-state freshness, control mode, and gateway controller/observer information.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  ] as any,
+}));
 
-// Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-  const { name, arguments: args } = request.params;
+  const { name } = request.params;
+  const args = (request.params.arguments ?? {}) as Record<string, unknown>;
 
   try {
     switch (name) {
       case 'disconnect_bot': {
-        const botName = args?.name as string;
-
-        if (!botName) {
-          return errorResponse('Bot name is required');
-        }
-
+        const botName = requireString(args.name, 'name');
         await botManager.disconnect(botName);
         return successResponse({ message: `Disconnected bot "${botName}"` });
       }
 
       case 'list_bots': {
-        const bots = botManager.list();
-        return successResponse({
-          bots,
-          count: bots.length
-        });
+        const bots = (await botManager.list()).map(bot => ({
+          ...bot,
+          executionBusy: executionQueue.isLocked(bot.name),
+        }));
+        return successResponse({ bots, count: bots.length });
+      }
+
+      case 'inspect_state': {
+        const botName = requireString(args.bot_name, 'bot_name');
+        const sections = optionalStringArray(args.sections, 'sections');
+        // Inspection intentionally returns cached state with an explicit age,
+        // even when stale, so agents can diagnose a stopped browser.
+        const connection = await botManager.ensureHealthy(botName, { requireFreshState: false });
+        return successResponse(inspectState(connection, sections));
+      }
+
+      case 'query_entities': {
+        const botName = requireString(args.bot_name, 'bot_name');
+        return await executionQueue.run(botName, async () => {
+          const connection = await botManager.ensureHealthy(botName);
+          const outcome = await runCancellableOperation(
+            () => queryEntities(connection, args),
+            extra.signal,
+          );
+          const response = outcome.status === 'success'
+            ? successResponse(outcome.value)
+            : errorResponse(outcome.error ?? `Entity query ${outcome.status}`);
+          return outcome.quiescence
+            ? holdQueueUntil(response, outcome.quiescence)
+            : response;
+        }, extra.signal);
+      }
+
+      case 'perform_action': {
+        const botName = requireString(args.bot_name, 'bot_name');
+        return await executionQueue.run(botName, async () => {
+          const connection = await botManager.ensureHealthy(botName);
+          const outcome = await runCancellableOperation(
+            () => performAction(connection, args),
+            extra.signal,
+          );
+          const response = outcome.status === 'success'
+            ? successResponse(outcome.value)
+            : errorResponse(outcome.error ?? `Action ${outcome.status}`);
+          return outcome.quiescence
+            ? holdQueueUntil(response, outcome.quiescence)
+            : response;
+        }, extra.signal);
       }
 
       case 'execute_code': {
-        const botName = args?.bot_name as string;
-        const code = args?.code as string;
-
-        if (!botName) {
-          return errorResponse('bot_name is required');
+        const botName = requireString(args.bot_name, 'bot_name');
+        const code = requireString(args.code, 'code');
+        if (code.length > 262_144) {
+          throw new Error('code exceeds the 262144-character execution limit');
         }
+        const timeoutMinutes = clampTimeoutMinutes(args.timeout);
 
-        if (!code) {
-          return errorResponse('code is required');
-        }
-
-        const isLongCode = code.length > 2000;
-
-        // Capture console output BEFORE connecting to prevent SDK logs from corrupting MCP JSON-RPC stdout
-        const logs: string[] = [];
-        const originalLog = console.log;
-        const originalWarn = console.warn;
-        const originalError = console.error;
-
-        console.log = (...args) => logs.push(args.map(a => typeof a === 'object' ? JSON.stringify(a, null, 2) : String(a)).join(' '));
-        console.warn = (...args) => logs.push('[warn] ' + args.map(a => typeof a === 'object' ? JSON.stringify(a, null, 2) : String(a)).join(' '));
-        // Don't capture console.error - let it go to stderr for MCP debugging
-
-        // Auto-connect if not already connected
-        let connection = botManager.get(botName);
-        if (!connection) {
-          console.error(`[MCP] Bot "${botName}" not connected, auto-connecting...`);
-          connection = await botManager.connect(botName);
-          // Wait up to 15s for initial world state after fresh connection
-          try {
-            await connection.sdk.waitForCondition(() => connection!.sdk.getState() !== null, 15000);
-          } catch {
-            console.error(`[MCP] Warning: initial state not received within 15s for bot "${botName}"`);
-          }
-        }
-
-        try {
-          const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-          const fn = new AsyncFunction('bot', 'sdk', code);
-
-          // Execute code with configurable timeout + MCP cancellation signal
-          const timeoutMinutes = Math.min(Math.max((args?.timeout as number) || 2, 0.1), 60);
-          const EXECUTION_TIMEOUT = timeoutMinutes * 60 * 1000;
-          let timeoutId: ReturnType<typeof setTimeout>;
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => reject(new Error(`Code execution timed out after ${timeoutMinutes} minute(s)`)), EXECUTION_TIMEOUT);
+        return await executionQueue.run(botName, async () => {
+          const connection = await botManager.ensureHealthy(botName);
+          const outcome = await executeUserCode({
+            bot: connection.bot,
+            sdk: connection.sdk,
+            code,
+            timeoutMs: timeoutMinutes * 60_000,
+            externalSignal: extra.signal,
+            logLimitChars: 48 * 1024,
           });
 
-          // AbortController that fires on MCP cancellation
-          const abortController = new AbortController();
-          const signal = abortController.signal;
-
-          if (extra.signal) {
-            if (extra.signal.aborted) {
-              abortController.abort(extra.signal.reason);
-            } else {
-              extra.signal.addEventListener('abort', () => {
-                console.error(`[MCP] execute_code cancelled by client for bot "${botName}"`);
-                abortController.abort('Cancelled by client');
-              }, { once: true });
-            }
-          }
-
-          const cancelPromise = new Promise<never>((_, reject) => {
-            signal.addEventListener('abort', () => {
-              reject(new Error(typeof signal.reason === 'string' ? signal.reason : 'Code execution cancelled'));
-            }, { once: true });
-          });
-
-          // Wrap bot and sdk in proxies that throw on every method call once cancelled
-          const cancellable = <T extends object>(target: T): T =>
-            new Proxy(target, {
-              get(obj, prop, receiver) {
-                const value = Reflect.get(obj, prop, receiver);
-                if (typeof value === 'function') {
-                  return (...args: any[]) => {
-                    if (signal.aborted) throw new Error('Execution cancelled');
-                    return value.apply(obj, args);
-                  };
-                }
-                return value;
-              }
-            });
-
-          let result: any;
-          try {
-            result = await Promise.race([fn(cancellable(connection.bot), cancellable(connection.sdk)), timeoutPromise, cancelPromise]);
-          } finally {
-            clearTimeout(timeoutId!);
-            if (!signal.aborted) abortController.abort('Execution finished');
-          }
-
-          // Build formatted output
-          const parts: string[] = [];
-
-          if (logs.length > 0) {
-            parts.push('── Console ──');
-            parts.push(logs.join('\n'));
-          }
-
-          if (result !== undefined) {
-            if (logs.length > 0) parts.push('');
-            parts.push('── Result ──');
-            parts.push(JSON.stringify(result, null, 2));
-          }
-
-          // Append formatted world state. The connection's tick cursor
-          // advances each call so repeat execute_code invocations only show
-          // NEW chat / system messages — old ones the bot already saw don't
-          // get re-emitted. Cursor lives on BotConnection (MCP-only concern)
-          // so the SDK surface stays minimal for script authors.
-          const state = connection.sdk.getState();
-          if (state) {
-            // Message ticks are the client's loopCycle, which restarts near 0
-            // when the bot page reloads. If every tick is below our cursor the
-            // client reloaded — reset the cursor or chat would be muted forever.
-            if (state.gameMessages && state.gameMessages.length > 0 &&
-                state.gameMessages.every(m => m.tick < connection.lastShownMessageTick)) {
-              connection.lastShownMessageTick = -1;
-            }
-            const sinceTick = connection.lastShownMessageTick;
-            if (state.gameMessages) {
-              for (const m of state.gameMessages) {
-                if (m.tick > connection.lastShownMessageTick) {
-                  connection.lastShownMessageTick = m.tick;
-                }
-              }
-            }
-            parts.push('');
-            parts.push('── World State ──');
-            parts.push(formatWorldState(state, connection.sdk.getStateAge(), { sinceTick }));
-          }
-
-          // Add reminder for long code
-          if (isLongCode) {
-            parts.push('');
-            parts.push('── Tip ──');
-            parts.push(`Long script detected. Consider writing to a .ts file and running with: bun run bots/${botName}/script.ts`);
-          }
-
-          const output = parts.length > 0 ? parts.join('\n') : '(no output)';
-
-          return {
-            content: [{ type: 'text', text: output }]
+          const response = {
+            content: [{
+              type: 'text' as const,
+              text: buildExecutionOutput(outcome, connection, code.length > 2_000),
+            }],
+            ...(outcome.status === 'success' ? {} : { isError: true }),
           };
-        } finally {
-          console.log = originalLog;
-          console.warn = originalWarn;
-          console.error = originalError;
-        }
+
+          // The public SDK cannot abort a call already in progress. Keep this
+          // bot's queue locked until that call settles so a new mutation cannot
+          // overlap it, while still returning timeout diagnostics immediately.
+          return outcome.quiescence
+            ? holdQueueUntil(response, outcome.quiescence)
+            : response;
+        }, extra.signal);
       }
 
       default:
-        throw new Error(`Unknown tool: ${name}`);
+        return errorResponse(`Unknown tool: ${name}`);
     }
-  } catch (error: any) {
-    const errorMessage = `Error: ${error.message}\n\nStack trace:\n${error.stack}`;
-    return {
-      content: [{ type: 'text', text: errorMessage }],
-      isError: true
-    };
+  } catch (error) {
+    return errorResponse(error instanceof Error ? error.message : String(error));
   }
 });
 
-function successResponse(data: any) {
+function successResponse(data: unknown) {
   return {
-    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }]
+    content: [{ type: 'text' as const, text: jsonResponseText(data) }],
   };
 }
 
 function errorResponse(message: string) {
   return {
-    content: [{ type: 'text', text: `Error: ${message}` }],
-    isError: true
+    content: [{ type: 'text' as const, text: `Error: ${message}` }],
+    isError: true,
   };
 }
 
-// Start server
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${field} is required`);
+  }
+  return value;
+}
+
+function optionalStringArray(value: unknown, field: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some(entry => typeof entry !== 'string')) {
+    throw new Error(`${field} must be an array of strings`);
+  }
+  return value;
+}
+
+function clampTimeoutMinutes(value: unknown): number {
+  if (value === undefined) return 2;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error('timeout must be a finite number of minutes');
+  }
+  return Math.min(Math.max(value, 0.1), 60);
+}
+
+function installStdioSafeConsole(): void {
+  // MCP reserves stdout for JSON-RPC. SDK diagnostics use console.log, so route
+  // process-level logs to stderr once. User code receives its own scoped
+  // console argument and never requires per-request global monkeypatching.
+  console.log = (...args: unknown[]) => console.error(...args);
+}
+
 async function main() {
-  console.error('[MCP Server] Starting RS-Agent MCP server v2.0...');
-  console.error('[MCP Server] Bots auto-connect on the first execute_code call.');
+  installStdioSafeConsole();
+  console.error('[MCP Server] Starting RS-Agent MCP server v2.1...');
+  console.error('[MCP Server] Bots auto-connect on first use. execute_code runs trusted code and is not sandboxed.');
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
@@ -345,7 +264,9 @@ async function main() {
   console.error('[MCP Server] Server running on stdio');
 }
 
-main().catch((error) => {
-  console.error('[MCP Server] Fatal error:', error);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch(error => {
+    console.error('[MCP Server] Fatal error:', error);
+    process.exit(1);
+  });
+}

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- serialize execute_code, perform_action, and scanning queries per bot, retaining the lock until already-started calls settle after cancellation or timeout
- transpile real TypeScript bodies, capture bounded request-scoped logs, bound all output, and preserve partial diagnostics plus terminal world state on failures
- health-check cached sessions and expose connection state, authentication, freshness, mode, controller/observer, and busy metadata
- add typed inspect_state, query_entities, and perform_action tools while retaining execute_code for advanced workflows
- track terminal messages with optional observation cursors so distinct same-tick publications are not suppressed
- exact-allowlist MCP resources, remove credential-prefix logging, keep stdout JSON-RPC safe, and document the trusted-code boundary

## Why

Benchmark runs repeatedly lost output on timeout, continued mutating after tool cancellation, collided through concurrent calls, reused stale cached sessions, and failed on TypeScript syntax despite the tool claiming TypeScript support. This PR moves those guarantees into one tested execution/session layer.

inspect_state supersedes the older, narrower get_state proposal in #1.

## Validation

- `bun test mcp`: 23 tests pass, 62 assertions
- `bun x tsc --noEmit -p mcp/tsconfig.json`
- `bun sdk/test/chat-history.test.ts`
- `bun sdk/test/click-dialog-by-text.test.ts`
- JSON-RPC stdio initialize/tools-list smoke test
- traversal attempt for /etc/passwd rejected
- `git diff --check`

## Known boundaries

- Public SDK methods do not yet accept AbortSignal. An already-started call cannot be forcibly stopped, so the queue stays locked until it settles; a never-settling promise requires disconnect or process restart.
- CPU-bound synchronous code cannot be pre-empted on the Bun event loop.
- Serialization is per MCP process, not across unrelated controllers.
- execute_code remains trusted, unsandboxed execution and transpiles rather than type-checks TypeScript.
- perform_action intentionally exposes the common validated high-level subset, not every BotActions method.
- No live game bot was used in validation.

Root tsc retains the two pre-existing banking nullability errors; PR #43 fixes those and adds repository-wide CI.
