### PR TITLE
Make high-level actions report observed, exact outcomes

### DIFF
--- a/sdk/action-reliability.ts
+++ b/sdk/action-reliability.ts
@@ -50,6 +50,38 @@ export interface QuantityOutcome {
     partial: boolean;
 }
 
+/** Upper bound for porcelain actions that expand a quantity into repeated packets. */
+export const MAX_ACTION_QUANTITY = 10_000;
+export const MAX_SHOP_ACTION_QUANTITY = 1_000;
+export const MAX_SHOP_ACTION_PACKETS = 100;
+export const SHOP_ACTION_DEADLINE_MS = 60_000;
+
+export type QuantityValidation =
+    | { valid: true; amount: number }
+    | { valid: false; message: string };
+
+/**
+ * Validate a quantity before it is serialized or used to control a loop.
+ * The -1 "all" sentinel is only accepted when explicitly enabled.
+ */
+export function validateActionQuantity(
+    amount: number,
+    options: { allowAll?: boolean; max?: number } = {},
+): QuantityValidation {
+    if (options.allowAll && amount === -1) return { valid: true, amount };
+    const max = options.max ?? MAX_ACTION_QUANTITY;
+    if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+        return { valid: false, message: 'Amount must be a finite number' };
+    }
+    if (!Number.isSafeInteger(amount) || amount <= 0) {
+        return { valid: false, message: 'Amount must be a positive safe integer' };
+    }
+    if (amount > max) {
+        return { valid: false, message: `Amount ${amount} exceeds the maximum ${max}` };
+    }
+    return { valid: true, amount };
+}
+
 /** Quantity success is exact: a non-zero partial fill is still unsuccessful. */
 export function classifyQuantity(requested: number, actual: number): QuantityOutcome {
     const normalizedRequested = Math.max(0, Math.floor(requested));

--- a/sdk/action-reliability.ts
+++ b/sdk/action-reliability.ts
@@ -1,0 +1,165 @@
+import type {
+    BotWorldState,
+    GameMessage,
+    InteractionEvidence,
+    InteractionWaitOptions,
+    InventoryItem,
+    InterfaceOption,
+} from './types';
+
+export type InterfaceOptionSelector = InterfaceOption | string | RegExp;
+
+function testPattern(pattern: string | RegExp, value: string): boolean {
+    if (typeof pattern === 'string') {
+        return value.toLowerCase().includes(pattern.toLowerCase());
+    }
+    pattern.lastIndex = 0;
+    return pattern.test(value);
+}
+
+/**
+ * Resolve a published interface option without mixing its human-facing
+ * 1-based `index` with its 0-based array position.
+ */
+export function resolveInterfaceOption(
+    options: readonly InterfaceOption[],
+    selector: InterfaceOptionSelector,
+): InterfaceOption | null {
+    if (typeof selector === 'object' && !(selector instanceof RegExp)) {
+        return options.find(option => option.componentId === selector.componentId) ?? null;
+    }
+    return options.find(option => testPattern(selector, option.text)) ?? null;
+}
+
+export function countInventoryItem(
+    inventory: readonly InventoryItem[],
+    target: number | string | RegExp,
+): number {
+    return inventory.reduce((total, item) => {
+        const matches = typeof target === 'number'
+            ? item.id === target
+            : testPattern(target, item.name);
+        return matches ? total + item.count : total;
+    }, 0);
+}
+
+export interface QuantityOutcome {
+    requested: number;
+    actual: number;
+    complete: boolean;
+    partial: boolean;
+}
+
+/** Quantity success is exact: a non-zero partial fill is still unsuccessful. */
+export function classifyQuantity(requested: number, actual: number): QuantityOutcome {
+    const normalizedRequested = Math.max(0, Math.floor(requested));
+    const normalizedActual = Math.max(0, Math.floor(actual));
+    return {
+        requested: normalizedRequested,
+        actual: normalizedActual,
+        complete: normalizedActual === normalizedRequested,
+        partial: normalizedActual > 0 && normalizedActual < normalizedRequested,
+    };
+}
+
+export interface InteractionBaseline {
+    state: BotWorldState;
+    inventory: string;
+    skills: string;
+    messageTick: number;
+    messageObservationId?: number;
+}
+
+export interface MessageBaseline {
+    messageTick: number;
+    messageObservationId?: number;
+}
+
+type ObservableMessage = GameMessage & { observationId?: number };
+
+/**
+ * Prefer a monotonic observation id when a newer state producer publishes it,
+ * while retaining tick-only compatibility with current producers.
+ */
+export function captureMessageBaseline(state: BotWorldState | null): MessageBaseline {
+    const messages = state?.gameMessages ?? [];
+    const observationIds = messages
+        .map(message => (message as ObservableMessage).observationId)
+        .filter((id): id is number => typeof id === 'number');
+    return {
+        messageTick: messages.reduce((max, message) => Math.max(max, message.tick), -1),
+        messageObservationId: observationIds.length > 0 ? Math.max(...observationIds) : undefined,
+    };
+}
+
+export function isMessageAfterBaseline(
+    message: GameMessage,
+    baseline: MessageBaseline,
+): boolean {
+    const observationId = (message as ObservableMessage).observationId;
+    if (typeof observationId === 'number' && typeof baseline.messageObservationId === 'number') {
+        return observationId > baseline.messageObservationId;
+    }
+    if (typeof observationId === 'number' && baseline.messageObservationId === undefined) {
+        return message.tick >= baseline.messageTick;
+    }
+    return message.tick > baseline.messageTick;
+}
+
+function inventorySignature(state: BotWorldState): string {
+    return state.inventory
+        .map(item => `${item.slot}:${item.id}:${item.count}`)
+        .sort()
+        .join('|');
+}
+
+function skillSignature(state: BotWorldState): string {
+    return state.skills
+        .map(skill => `${skill.name}:${skill.experience}`)
+        .sort()
+        .join('|');
+}
+
+export function captureInteractionBaseline(state: BotWorldState): InteractionBaseline {
+    const messages = captureMessageBaseline(state);
+    return {
+        state,
+        inventory: inventorySignature(state),
+        skills: skillSignature(state),
+        ...messages,
+    };
+}
+
+export function detectInteractionEvidence(
+    state: BotWorldState,
+    baseline: InteractionBaseline,
+    options: InteractionWaitOptions = {},
+): InteractionEvidence | null {
+    if (!baseline.state.dialog.isOpen && state.dialog.isOpen) return 'dialog';
+    if (
+        (!baseline.state.interface?.isOpen && state.interface?.isOpen) ||
+        (state.interface?.isOpen &&
+            baseline.state.interface?.interfaceId !== state.interface.interfaceId)
+    ) {
+        return 'interface';
+    }
+    if (
+        state.player &&
+        baseline.state.player &&
+        state.player.animId !== -1 &&
+        state.player.animId !== baseline.state.player.animId
+    ) {
+        return 'animation';
+    }
+    if (inventorySignature(state) !== baseline.inventory) return 'inventory';
+    if (skillSignature(state) !== baseline.skills) return 'xp';
+
+    if (options.message) {
+        const matched = state.gameMessages.some(message =>
+            isMessageAfterBaseline(message, baseline) && testPattern(options.message!, message.text)
+        );
+        if (matched) return 'message';
+    }
+    if (options.evidence?.(state, baseline.state)) return 'custom';
+    return null;
+}

--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -53,13 +53,18 @@ import {
     countInventoryItem,
     detectInteractionEvidence,
     isMessageAfterBaseline,
-    resolveInterfaceOption,
+    MAX_SHOP_ACTION_PACKETS,
+    MAX_SHOP_ACTION_QUANTITY,
+    SHOP_ACTION_DEADLINE_MS,
+    validateActionQuantity,
 } from './action-reliability';
 import {
     findProducedItem,
+    matchingProductOptions,
     productPosition,
     resolveFletchProduct,
     resolveLeatherProduct,
+    resolveMakeOneOption,
 } from './crafting-products';
 
 // Modal interfaces dismissBlockingUI must never auto-close: closing these is
@@ -1106,6 +1111,16 @@ export class BotActions {
 
     /** Buy an item from an open shop .*/
     async buyFromShop(target: ShopItem | string | RegExp, amount: number = 1): Promise<ShopResult> {
+        const validatedAmount = validateActionQuantity(amount, { max: MAX_SHOP_ACTION_QUANTITY });
+        if (!validatedAmount.valid) {
+            return {
+                success: false,
+                message: validatedAmount.message,
+                phase: 'validation',
+                reason: 'invalid_amount',
+            };
+        }
+        const requestedAmount = validatedAmount.amount;
         const shop = this.sdk.getState()?.shop;
         if (!shop?.isOpen) {
             return { success: false, message: 'Shop is not open', phase: 'validation', reason: 'shop_not_open' };
@@ -1128,7 +1143,6 @@ export class BotActions {
                 .reduce((sum, i) => sum + i.count, 0);
 
         const totalBefore = countInvItems();
-        const requestedAmount = Math.max(1, Math.floor(amount));
         const outcome = (failure: 'dispatch_failed' | 'timeout' = 'timeout'): ShopResult => {
             const amountBought = Math.max(0, countInvItems() - totalBefore);
             const quantity = classifyQuantity(requestedAmount, amountBought);
@@ -1147,16 +1161,16 @@ export class BotActions {
             };
         };
 
-        // Decompose amount into valid buy commands (10, 5, 1)
+        // Stream bounded buy commands instead of materializing an amount-sized array.
         let remaining = requestedAmount;
-        const buySteps: number[] = [];
-        while (remaining > 0) {
-            if (remaining >= 10) { buySteps.push(10); remaining -= 10; }
-            else if (remaining >= 5) { buySteps.push(5); remaining -= 5; }
-            else { buySteps.push(1); remaining -= 1; }
-        }
-
-        for (const stepAmount of buySteps) {
+        let packetsSent = 0;
+        const deadline = Date.now() + Math.min(SHOP_ACTION_DEADLINE_MS, this.sdk.config.actionTimeout);
+        while (
+            remaining > 0 &&
+            packetsSent < MAX_SHOP_ACTION_PACKETS &&
+            Date.now() < deadline
+        ) {
+            const stepAmount = remaining >= 10 ? 10 : remaining >= 5 ? 5 : 1;
             const countBefore = countInvItems();
 
             const result = await this.sdk.sendShopBuy(shopItem.slot, stepAmount);
@@ -1165,6 +1179,7 @@ export class BotActions {
                 if (failed.amountBought === 0) failed.message = result.message;
                 return failed;
             }
+            packetsSent++;
 
             try {
                 await this.sdk.waitForCondition(state => {
@@ -1176,6 +1191,7 @@ export class BotActions {
             } catch {
                 return outcome('timeout');
             }
+            remaining -= stepAmount;
         }
 
         return outcome();
@@ -1183,6 +1199,17 @@ export class BotActions {
 
     /** Sell an item to an open shop. */
     async sellToShop(target: InventoryItem | ShopItem | string | RegExp, amount: SellAmount = 1): Promise<ShopSellResult> {
+        const validatedAmount = amount === 'all'
+            ? null
+            : validateActionQuantity(amount, { max: MAX_SHOP_ACTION_QUANTITY });
+        if (validatedAmount && !validatedAmount.valid) {
+            return {
+                success: false,
+                message: validatedAmount.message,
+                phase: 'validation',
+                reason: 'invalid_amount',
+            };
+        }
         const shop = this.sdk.getState()?.shop;
         if (!shop?.isOpen) {
             return { success: false, message: 'Shop is not open', phase: 'validation', reason: 'shop_not_open' };
@@ -1210,17 +1237,8 @@ export class BotActions {
         const getTotalCount = (playerItems: typeof shop.playerItems) =>
             playerItems.filter(i => i.id === sellItem.id).reduce((sum, i) => sum + i.count, 0);
 
-        // Decompose amount into valid sell commands (10, 5, 1)
-        let remaining = Math.max(1, Math.floor(amount));
-        const sellSteps: number[] = [];
-        while (remaining > 0) {
-            if (remaining >= 10) { sellSteps.push(10); remaining -= 10; }
-            else if (remaining >= 5) { sellSteps.push(5); remaining -= 5; }
-            else { sellSteps.push(1); remaining -= 1; }
-        }
-
         const totalCountBefore = getTotalCount(shop.playerItems);
-        const requestedAmount = Math.max(1, Math.floor(amount));
+        const requestedAmount = validatedAmount!.amount;
         const outcome = (
             failure: 'dispatch_failed' | 'rejected' | 'timeout' = 'timeout',
             rejected = false,
@@ -1246,15 +1264,29 @@ export class BotActions {
             };
         };
 
-        for (const stepAmount of sellSteps) {
-            const countBefore = getTotalCount(this.sdk.getState()?.shop.playerItems ?? []);
+        // Stream bounded sell commands and resolve a currently occupied slot
+        // before every dispatch (non-stackable batches remove the anchor slot).
+        let remaining = requestedAmount;
+        let packetsSent = 0;
+        const deadline = Date.now() + Math.min(SHOP_ACTION_DEADLINE_MS, this.sdk.config.actionTimeout);
+        while (
+            remaining > 0 &&
+            packetsSent < MAX_SHOP_ACTION_PACKETS &&
+            Date.now() < deadline
+        ) {
+            const currentPlayerItems = this.sdk.getState()?.shop.playerItems ?? [];
+            const currentSellItem = currentPlayerItems.find(item => item.id === sellItem.id);
+            if (!currentSellItem) return outcome('timeout');
+            const countBefore = getTotalCount(currentPlayerItems);
+            const stepAmount = remaining >= 10 ? 10 : remaining >= 5 ? 5 : 1;
 
-            const result = await this.sdk.sendShopSell(sellItem.slot, stepAmount);
+            const result = await this.sdk.sendShopSell(currentSellItem.slot, stepAmount);
             if (!result.success) {
                 const failed = outcome('dispatch_failed');
                 if (failed.amountSold === 0) failed.message = result.message;
                 return failed;
             }
+            packetsSent++;
 
             try {
                 const finalState = await this.sdk.waitForCondition(state => {
@@ -1294,6 +1326,7 @@ export class BotActions {
             } catch {
                 return outcome('timeout');
             }
+            remaining -= stepAmount;
         }
 
         return outcome();
@@ -1305,12 +1338,14 @@ export class BotActions {
         msgBaseline: ReturnType<typeof captureMessageBaseline>,
     ): Promise<ShopSellResult> {
         let totalSold = 0;
+        let packetsSent = 0;
+        const deadline = Date.now() + Math.min(SHOP_ACTION_DEADLINE_MS, this.sdk.config.actionTimeout);
 
         const getTotalCount = (playerItems: ShopItem[]) => {
             return playerItems.filter(i => i.id === sellItem.id).reduce((sum, i) => sum + i.count, 0);
         };
 
-        while (true) {
+        while (packetsSent < MAX_SHOP_ACTION_PACKETS && Date.now() < deadline) {
             const state = this.sdk.getState();
             if (!state?.shop.isOpen) {
                 break;
@@ -1329,6 +1364,7 @@ export class BotActions {
             if (!result.success) {
                 break;
             }
+            packetsSent++;
 
             try {
                 const finalState = await this.sdk.waitForCondition(s => {
@@ -1563,6 +1599,16 @@ export class BotActions {
 
     /** Deposit an item into the bank. Use -1 for all. */
     async depositItem(target: InventoryItem | string | RegExp, amount: number = -1): Promise<BankDepositResult> {
+        const validatedAmount = validateActionQuantity(amount, { allowAll: true });
+        if (!validatedAmount.valid) {
+            return {
+                success: false,
+                message: validatedAmount.message,
+                phase: 'validation',
+                reason: 'invalid_amount',
+            };
+        }
+        const dispatchAmount = validatedAmount.amount;
         const state = this.sdk.getState();
         if (!state?.interface?.isOpen) {
             return {
@@ -1573,7 +1619,14 @@ export class BotActions {
             };
         }
 
-        const item = this.helpers.resolveInventoryItem(target, /./);
+        let item: InventoryItem | null;
+        if (typeof target === 'object' && 'slot' in target) {
+            item = state.inventory.find(current =>
+                current.slot === target.slot && current.id === target.id
+            ) ?? state.inventory.find(current => current.id === target.id) ?? null;
+        } else {
+            item = this.helpers.resolveInventoryItem(target, /./);
+        }
         if (!item) {
             return {
                 success: false,
@@ -1584,8 +1637,8 @@ export class BotActions {
         }
 
         const countBefore = state.inventory.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0);
-        const requestedAmount = amount === -1 ? countBefore : Math.max(1, Math.floor(amount));
-        const dispatch = await this.sdk.sendBankDeposit(item.slot, amount);
+        const requestedAmount = dispatchAmount === -1 ? countBefore : dispatchAmount;
+        const dispatch = await this.sdk.sendBankDeposit(item.slot, dispatchAmount);
         if (!dispatch.success) {
             return {
                 success: false,
@@ -1635,6 +1688,16 @@ export class BotActions {
 
     /** Withdraw an item from the bank by slot number. */
     async withdrawItem(target: BankItem | string | RegExp | number, amount: number = 1): Promise<BankWithdrawResult> {
+        const validatedAmount = validateActionQuantity(amount, { allowAll: true });
+        if (!validatedAmount.valid) {
+            return {
+                success: false,
+                message: validatedAmount.message,
+                phase: 'validation',
+                reason: 'invalid_amount',
+            };
+        }
+        const dispatchAmount = validatedAmount.amount;
         const state = this.sdk.getState();
         if (!state?.interface?.isOpen) {
             return {
@@ -1649,7 +1712,9 @@ export class BotActions {
         if (typeof target === 'number') {
             bankItem = state.bank.items.find(item => item.slot === target);
         } else if (typeof target === 'object' && 'slot' in target) {
-            bankItem = state.bank.items.find(item => item.slot === target.slot) ?? target;
+            bankItem = state.bank.items.find(item =>
+                item.slot === target.slot && item.id === target.id
+            ) ?? state.bank.items.find(item => item.id === target.id);
         } else {
             bankItem = this.sdk.findBankItem(target) ?? undefined;
         }
@@ -1663,8 +1728,11 @@ export class BotActions {
         }
 
         const countBefore = countInventoryItem(state.inventory, bankItem.id);
-        const requestedAmount = amount === -1 ? bankItem.count : Math.max(1, Math.floor(amount));
-        const dispatch = await this.sdk.sendBankWithdraw(bankItem.slot, amount);
+        const bankCountBefore = state.bank.items
+            .filter(item => item.id === bankItem!.id)
+            .reduce((sum, item) => sum + item.count, 0);
+        const requestedAmount = dispatchAmount === -1 ? bankItem.count : dispatchAmount;
+        const dispatch = await this.sdk.sendBankWithdraw(bankItem.slot, dispatchAmount);
         if (!dispatch.success) {
             return {
                 success: false,
@@ -1679,14 +1747,34 @@ export class BotActions {
 
         try {
             const finalState = await this.sdk.waitForCondition(s => {
-                return countInventoryItem(s.inventory, bankItem!.id) > countBefore;
+                const inventoryIncreased = countInventoryItem(s.inventory, bankItem!.id) > countBefore;
+                const bankCountNow = s.bank.items
+                    .filter(item => item.id === bankItem!.id)
+                    .reduce((sum, item) => sum + item.count, 0);
+                return inventoryIncreased || bankCountNow < bankCountBefore;
             }, 5000);
-            const amountWithdrawn = Math.max(
+            const bankCountAfter = finalState.bank.items
+                .filter(item => item.id === bankItem.id)
+                .reduce((sum, item) => sum + item.count, 0);
+            const bankDecrease = Math.max(0, bankCountBefore - bankCountAfter);
+            const inventoryIncrease = Math.max(
                 0,
                 countInventoryItem(finalState.inventory, bankItem.id) - countBefore,
             );
+            const amountWithdrawn = Math.max(
+                bankDecrease,
+                inventoryIncrease,
+            );
             const quantity = classifyQuantity(requestedAmount, amountWithdrawn);
-            const newItem = finalState.inventory.find(item => item.id === bankItem.id);
+            const newItem = finalState.inventory.find(after => {
+                const beforeCount = state.inventory
+                    .filter(before => before.id === after.id)
+                    .reduce((sum, before) => sum + before.count, 0);
+                const afterCount = finalState.inventory
+                    .filter(candidate => candidate.id === after.id)
+                    .reduce((sum, candidate) => sum + candidate.count, 0);
+                return afterCount > beforeCount;
+            });
             return {
                 success: quantity.complete,
                 message: quantity.complete
@@ -2102,8 +2190,9 @@ export class BotActions {
         const position = productPosition(requestedProduct, higherTierLogs);
         let selection: ActionResult | null = null;
         if (state.interface?.isOpen) {
-            const option = resolveInterfaceOption(state.interface.options, requestedProduct.optionPattern)
-                ?? state.interface.options[position]
+            const matchingOptions = matchingProductOptions(state.interface.options, requestedProduct);
+            const option = resolveMakeOneOption(state.interface.options, requestedProduct)
+                ?? (matchingOptions.length === 0 ? state.interface.options[position] : null)
                 ?? null;
             selection = option ? await this.sdk.clickInterfaceOption(option) : null;
         } else if (state.dialog.isOpen) {
@@ -2220,8 +2309,9 @@ export class BotActions {
         const position = productPosition(requestedProduct, false);
         let selection: ActionResult | null = null;
         if (state.interface?.isOpen) {
-            const option = resolveInterfaceOption(state.interface.options, requestedProduct.optionPattern)
-                ?? state.interface.options[position]
+            const matchingOptions = matchingProductOptions(state.interface.options, requestedProduct);
+            const option = resolveMakeOneOption(state.interface.options, requestedProduct)
+                ?? (matchingOptions.length === 0 ? state.interface.options[position] : null)
                 ?? null;
             selection = option ? await this.sdk.clickInterfaceOption(option) : null;
         } else if (state.dialog.isOpen) {

--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -37,6 +37,7 @@ import type {
     UseItemOnNpcResult,
     InteractLocResult,
     InteractNpcResult,
+    InteractionWaitOptions,
     PickpocketResult,
     PrayerResult,
     PrayerName,
@@ -45,6 +46,21 @@ import type {
     StringAmuletResult,
 } from './types';
 import { PRAYER_INDICES, PRAYER_NAMES, PRAYER_LEVELS } from './types';
+import {
+    captureInteractionBaseline,
+    captureMessageBaseline,
+    classifyQuantity,
+    countInventoryItem,
+    detectInteractionEvidence,
+    isMessageAfterBaseline,
+    resolveInterfaceOption,
+} from './action-reliability';
+import {
+    findProducedItem,
+    productPosition,
+    resolveFletchProduct,
+    resolveLeatherProduct,
+} from './crafting-products';
 
 // Modal interfaces dismissBlockingUI must never auto-close: closing these is
 // destructive (declines a two-party screen) or strands the player (must be
@@ -518,29 +534,67 @@ export class BotActions {
 
         const tree = this.helpers.resolveLocation(target, /^tree$/i);
         if (!tree) {
-            return { success: false, message: 'No tree found' };
+            return { success: false, message: 'No tree found', phase: 'validation', reason: 'tree_not_found' };
+        }
+        const inventoryBefore = [...this.sdk.getInventory()];
+        if (inventoryBefore.length >= 28) {
+            return { success: false, message: 'Inventory is full', phase: 'validation', reason: 'inventory_full' };
         }
 
-        const invCountBefore = this.sdk.getInventory().length;
+        const msgBaseline = captureMessageBaseline(this.sdk.getState());
         const result = await this.sdk.sendInteractLoc(tree.x, tree.z, tree.id, 1);
-
         if (!result.success) {
-            return { success: false, message: result.message };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
+        let failure: 'cant_reach' | 'inventory_full' | null = null;
+        let levelInterrupted = false;
         try {
-            await this.sdk.waitForCondition(state => {
-                const newItem = state.inventory.length > invCountBefore;
-                const treeGone = !state.nearbyLocs.find(l =>
-                    l.x === tree.x && l.z === tree.z && l.id === tree.id
-                );
-                return newItem || treeGone;
+            const finalState = await this.sdk.waitForCondition(state => {
+                for (const message of state.gameMessages) {
+                    if (!isMessageAfterBaseline(message, msgBaseline)) continue;
+                    if (/can't reach|cannot reach/i.test(message.text)) failure = 'cant_reach';
+                    if (/inventory.*full/i.test(message.text)) failure = 'inventory_full';
+                }
+                if (state.dialog.isOpen) levelInterrupted = true;
+                const gainedLogs = countInventoryItem(state.inventory, /logs/i) >
+                    countInventoryItem(inventoryBefore, /logs/i);
+                return failure !== null || gainedLogs || levelInterrupted;
             }, 30000);
-
-            const logs = this.sdk.findInventoryItem(/logs/i);
-            return { success: true, logs: logs || undefined, message: 'Chopped tree' };
+            if (failure) {
+                return {
+                    success: false,
+                    message: failure === 'cant_reach' ? `Cannot reach ${tree.name}` : 'Inventory is full',
+                    phase: 'observation',
+                    reason: failure,
+                };
+            }
+            const gainedLogs = countInventoryItem(finalState.inventory, /logs/i) >
+                countInventoryItem(inventoryBefore, /logs/i);
+            if (!gainedLogs && levelInterrupted) {
+                return {
+                    success: false,
+                    message: 'Tree chop was interrupted by a level-up dialog',
+                    phase: 'observation',
+                    reason: 'level_interrupted',
+                };
+            }
+            const logs = finalState.inventory.find(item => /logs/i.test(item.name));
+            return {
+                success: true,
+                logs,
+                message: `Chopped ${tree.name}`,
+                phase: 'completion',
+            };
         } catch {
-            return { success: false, message: 'Timed out waiting for tree chop' };
+            return {
+                success: false,
+                message: levelInterrupted
+                    ? 'Tree chop was interrupted by a level-up dialog'
+                    : 'Timed out waiting for logs from tree chop',
+                phase: 'observation',
+                reason: levelInterrupted ? 'level_interrupted' : 'timeout',
+            };
         }
     }
 
@@ -550,60 +604,98 @@ export class BotActions {
 
         const tinderbox = this.sdk.findInventoryItem(/tinderbox/i);
         if (!tinderbox) {
-            return { success: false, xpGained: 0, message: 'No tinderbox in inventory' };
+            return {
+                success: false,
+                xpGained: 0,
+                message: 'No tinderbox in inventory',
+                phase: 'validation',
+                reason: 'no_tinderbox',
+            };
         }
 
         const logs = this.helpers.resolveInventoryItem(logsTarget, /logs/i);
         if (!logs) {
-            return { success: false, xpGained: 0, message: 'No logs in inventory' };
+            return {
+                success: false,
+                xpGained: 0,
+                message: 'No logs in inventory',
+                phase: 'validation',
+                reason: 'no_logs',
+            };
         }
 
         const fmBefore = this.sdk.getSkill('Firemaking')?.experience || 0;
-
+        const logsBefore = countInventoryItem(this.sdk.getInventory(), logs.id);
+        const msgBaseline = captureMessageBaseline(this.sdk.getState());
         const result = await this.sdk.sendUseItemOnItem(tinderbox.slot, logs.slot);
         if (!result.success) {
-            return { success: false, xpGained: 0, message: result.message };
+            return {
+                success: false,
+                xpGained: 0,
+                message: result.message,
+                phase: 'dispatch',
+                reason: 'dispatch_failed',
+            };
         }
 
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
-        let lastDialogClickTick = 0;
-
+        let failure: 'cant_reach' | 'bad_location' | null = null;
+        let levelInterrupted = false;
         try {
-            await this.sdk.waitForCondition(state => {
+            const finalState = await this.sdk.waitForCondition(state => {
                 const fmXp = state.skills.find(s => s.name === 'Firemaking')?.experience || 0;
-                if (fmXp > fmBefore) {
-                    return true;
-                }
-
-                if (state.dialog.isOpen && (state.tick - lastDialogClickTick) >= 3) {
-                    lastDialogClickTick = state.tick;
-                    this.sdk.sendClickDialog(0).catch(() => {});
-                }
-
-                const failureMessages = ["can't light a fire", "you need to move", "can't do that here"];
-                for (const msg of state.gameMessages) {
-                    if (msg.tick > msgBaseline) {
-                        const text = msg.text.toLowerCase();
-                        if (failureMessages.some(f => text.includes(f))) {
-                            return true;
-                        }
+                if (state.dialog.isOpen) levelInterrupted = true;
+                for (const message of state.gameMessages) {
+                    if (!isMessageAfterBaseline(message, msgBaseline)) continue;
+                    if (/can't reach|cannot reach/i.test(message.text)) failure = 'cant_reach';
+                    if (/can't light a fire|need to move|can't do that here/i.test(message.text)) {
+                        failure = 'bad_location';
                     }
                 }
-
-                return false;
+                const logsConsumed = logsBefore - countInventoryItem(state.inventory, logs.id);
+                return failure !== null || fmXp > fmBefore || logsConsumed > 0 || levelInterrupted;
             }, 30000);
 
-            const fmAfter = this.sdk.getSkill('Firemaking')?.experience || 0;
+            if (failure) {
+                return {
+                    success: false,
+                    xpGained: 0,
+                    logsConsumed: 0,
+                    message: failure === 'cant_reach' ? 'Cannot reach a place to light the logs' : 'Cannot light a fire here',
+                    phase: 'observation',
+                    reason: failure,
+                };
+            }
+            const fmAfter = finalState.skills.find(skill => skill.name === 'Firemaking')?.experience || 0;
             const xpGained = fmAfter - fmBefore;
-
+            const logsConsumed = Math.max(0, logsBefore - countInventoryItem(finalState.inventory, logs.id));
+            if (xpGained === 0 && logsConsumed === 0 && levelInterrupted) {
+                return {
+                    success: false,
+                    xpGained: 0,
+                    logsConsumed: 0,
+                    message: 'Firemaking was interrupted by a level-up dialog',
+                    phase: 'observation',
+                    reason: 'level_interrupted',
+                };
+            }
             return {
-                success: xpGained > 0,
+                success: xpGained > 0 || logsConsumed > 0,
                 xpGained,
-                message: xpGained > 0 ? 'Burned logs' : 'Failed to light fire (possibly bad location)'
+                logsConsumed,
+                message: 'Burned logs',
+                phase: 'completion',
             };
         } catch {
-            return { success: false, xpGained: 0, message: 'Timed out waiting for fire' };
+            return {
+                success: false,
+                xpGained: 0,
+                logsConsumed: 0,
+                message: levelInterrupted
+                    ? 'Firemaking was interrupted by a level-up dialog'
+                    : 'Timed out waiting for fire',
+                phase: 'observation',
+                reason: levelInterrupted ? 'level_interrupted' : 'timeout',
+            };
         }
     }
 
@@ -702,19 +794,27 @@ export class BotActions {
     }
 
     /** Talk to an NPC and wait for dialog to open. Walks to the NPC first (handling doors). */
-    async talkTo(target: NearbyNpc | string | RegExp): Promise<TalkResult> {
+    async talkTo(
+        target: NearbyNpc | string | RegExp,
+        options: Pick<InteractionWaitOptions, 'timeout'> = {},
+    ): Promise<TalkResult> {
         await this.dismissBlockingUI();
 
         const npc = this.helpers.resolveNpc(target);
         if (!npc) {
-            return { success: false, message: 'NPC not found' };
+            return { success: false, message: 'NPC not found', phase: 'validation', reason: 'npc_not_found' };
         }
 
         // Walk to the NPC first (handles doors)
         if (npc.distance > 2) {
             const walkResult = await this.walkTo(npc.x, npc.z, 2);
             if (!walkResult.success) {
-                return { success: false, message: `Cannot reach ${npc.name}: ${walkResult.message}` };
+                return {
+                    success: false,
+                    message: `Cannot reach ${npc.name}: ${walkResult.message}`,
+                    phase: 'routing',
+                    reason: 'cant_reach',
+                };
             }
         }
 
@@ -722,57 +822,56 @@ export class BotActions {
         const npcPattern = typeof target === 'object' ? new RegExp(npc.name, 'i') : target;
         const npcNow = this.helpers.resolveNpc(npcPattern);
         if (!npcNow) {
-            return { success: false, message: `${npc.name} no longer visible` };
+            return {
+                success: false,
+                message: `${npc.name} no longer visible`,
+                phase: 'validation',
+                reason: 'npc_not_found',
+            };
         }
 
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
-        let lastMoveTick = startTick;
-        let lastX = this.sdk.getState()?.player?.x ?? 0;
-        let lastZ = this.sdk.getState()?.player?.z ?? 0;
-
+        const initialState = this.sdk.getState();
+        if (!initialState) {
+            return { success: false, message: 'No game state', phase: 'observation', reason: 'timeout' };
+        }
+        const baseline = captureInteractionBaseline(initialState);
         const result = await this.sdk.sendTalkToNpc(npcNow.index);
         if (!result.success) {
-            return { success: false, message: result.message };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
         try {
             const finalState = await this.sdk.waitForCondition(state => {
-                // Check for can't-reach messages
-                for (const msg of state.gameMessages) {
-                    if (msg.tick > msgBaseline) {
-                        const text = msg.text.toLowerCase();
-                        if (text.includes("can't reach") || text.includes("cannot reach")) return true;
-                    }
-                }
+                const cantReach = state.gameMessages.some(message =>
+                    isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+                );
+                return cantReach || (!initialState.dialog.isOpen && state.dialog.isOpen);
+            }, options.timeout ?? 10000);
 
-                // Dialog opened — success
-                if (state.dialog.isOpen) return true;
-
-                // Track movement
-                if (state.player && (state.player.x !== lastX || state.player.z !== lastZ)) {
-                    lastX = state.player.x;
-                    lastZ = state.player.z;
-                    lastMoveTick = state.tick;
-                }
-
-                // Player idle for 2+ ticks with no dialog → give up
-                if (state.tick - lastMoveTick >= 2) return true;
-
-                return false;
-            }, 30000); // safety net only
-
-            if (this.helpers.checkCantReachMessage(msgBaseline)) {
-                return { success: false, message: `Cannot reach ${npcNow.name}` };
+            const cantReach = finalState.gameMessages.some(message =>
+                isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+            );
+            if (cantReach) {
+                return {
+                    success: false,
+                    message: `Cannot reach ${npcNow.name}`,
+                    phase: 'observation',
+                    reason: 'cant_reach',
+                };
             }
-
-            if (finalState.dialog.isOpen) {
-                return { success: true, dialog: finalState.dialog, message: `Talking to ${npcNow.name}` };
-            }
-
-            return { success: false, message: 'Dialog did not open' };
+            return {
+                success: true,
+                dialog: finalState.dialog,
+                message: `Talking to ${npcNow.name}`,
+                phase: 'completion',
+            };
         } catch {
-            return { success: false, message: 'Timed out waiting for dialog' };
+            return {
+                success: false,
+                message: `Timed out waiting ${options.timeout ?? 10000}ms for dialog`,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
     }
 
@@ -1009,12 +1108,17 @@ export class BotActions {
     async buyFromShop(target: ShopItem | string | RegExp, amount: number = 1): Promise<ShopResult> {
         const shop = this.sdk.getState()?.shop;
         if (!shop?.isOpen) {
-            return { success: false, message: 'Shop is not open' };
+            return { success: false, message: 'Shop is not open', phase: 'validation', reason: 'shop_not_open' };
         }
 
         const shopItem = this.helpers.resolveShopItem(target, shop.shopItems);
         if (!shopItem) {
-            return { success: false, message: `Item not found in shop: ${target}` };
+            return {
+                success: false,
+                message: `Item not found in shop: ${target}`,
+                phase: 'validation',
+                reason: 'item_not_found',
+            };
         }
 
         // Count total items across all inventory slots (handles non-stackable items)
@@ -1024,9 +1128,27 @@ export class BotActions {
                 .reduce((sum, i) => sum + i.count, 0);
 
         const totalBefore = countInvItems();
+        const requestedAmount = Math.max(1, Math.floor(amount));
+        const outcome = (failure: 'dispatch_failed' | 'timeout' = 'timeout'): ShopResult => {
+            const amountBought = Math.max(0, countInvItems() - totalBefore);
+            const quantity = classifyQuantity(requestedAmount, amountBought);
+            const boughtItem = this.sdk.getInventory().find(item => item.id === shopItem.id);
+            return {
+                success: quantity.complete,
+                item: boughtItem,
+                requestedAmount,
+                amountBought,
+                partial: quantity.partial,
+                message: quantity.complete
+                    ? `Bought ${shopItem.name} x${amountBought}`
+                    : `Bought ${shopItem.name} x${amountBought}; requested ${requestedAmount}`,
+                phase: quantity.complete ? 'completion' : 'observation',
+                reason: quantity.complete ? undefined : quantity.partial ? 'partial_fill' : failure,
+            };
+        };
 
         // Decompose amount into valid buy commands (10, 5, 1)
-        let remaining = Math.max(1, Math.floor(amount));
+        let remaining = requestedAmount;
         const buySteps: number[] = [];
         while (remaining > 0) {
             if (remaining >= 10) { buySteps.push(10); remaining -= 10; }
@@ -1039,12 +1161,9 @@ export class BotActions {
 
             const result = await this.sdk.sendShopBuy(shopItem.slot, stepAmount);
             if (!result.success) {
-                const totalBought = countInvItems() - totalBefore;
-                if (totalBought > 0) {
-                    const boughtItem = this.sdk.getInventory().find(i => i.id === shopItem.id);
-                    return { success: true, item: boughtItem, message: `Bought ${shopItem.name} x${totalBought} (wanted ${amount})` };
-                }
-                return { success: false, message: result.message };
+                const failed = outcome('dispatch_failed');
+                if (failed.amountBought === 0) failed.message = result.message;
+                return failed;
             }
 
             try {
@@ -1055,37 +1174,37 @@ export class BotActions {
                     return total > countBefore;
                 }, 5000);
             } catch {
-                const totalBought = countInvItems() - totalBefore;
-                if (totalBought > 0) {
-                    const boughtItem = this.sdk.getInventory().find(i => i.id === shopItem.id);
-                    return { success: true, item: boughtItem, message: `Bought ${shopItem.name} x${totalBought} (wanted ${amount})` };
-                }
-                return { success: false, message: `Failed to buy ${shopItem.name} (no coins or out of stock?)` };
+                return outcome('timeout');
             }
         }
 
-        const totalBought = countInvItems() - totalBefore;
-        const boughtItem = this.sdk.getInventory().find(i => i.id === shopItem.id);
-        return { success: true, item: boughtItem, message: `Bought ${shopItem.name} x${totalBought}` };
+        return outcome();
     }
 
     /** Sell an item to an open shop. */
     async sellToShop(target: InventoryItem | ShopItem | string | RegExp, amount: SellAmount = 1): Promise<ShopSellResult> {
         const shop = this.sdk.getState()?.shop;
         if (!shop?.isOpen) {
-            return { success: false, message: 'Shop is not open' };
+            return { success: false, message: 'Shop is not open', phase: 'validation', reason: 'shop_not_open' };
         }
 
         const sellItem = this.helpers.resolveShopItem(target, shop.playerItems);
         if (!sellItem) {
-            return { success: false, message: `Item not found to sell: ${target}` };
+            return {
+                success: false,
+                message: `Item not found to sell: ${target}`,
+                phase: 'validation',
+                reason: 'item_not_found',
+            };
         }
 
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
+        const msgBaseline = captureMessageBaseline(this.sdk.getState());
 
         if (amount === 'all') {
-            return this.sellAllToShop(sellItem, startTick, msgBaseline);
+            const requestedAmount = shop.playerItems
+                .filter(item => item.id === sellItem.id)
+                .reduce((sum, item) => sum + item.count, 0);
+            return this.sellAllToShop(sellItem, requestedAmount, msgBaseline);
         }
 
         const getTotalCount = (playerItems: typeof shop.playerItems) =>
@@ -1101,23 +1220,46 @@ export class BotActions {
         }
 
         const totalCountBefore = getTotalCount(shop.playerItems);
+        const requestedAmount = Math.max(1, Math.floor(amount));
+        const outcome = (
+            failure: 'dispatch_failed' | 'rejected' | 'timeout' = 'timeout',
+            rejected = false,
+        ): ShopSellResult => {
+            const amountSold = Math.max(
+                0,
+                totalCountBefore - getTotalCount(this.sdk.getState()?.shop.playerItems ?? []),
+            );
+            const quantity = classifyQuantity(requestedAmount, amountSold);
+            return {
+                success: quantity.complete && !rejected,
+                requestedAmount,
+                amountSold,
+                partial: quantity.partial,
+                rejected,
+                message: quantity.complete && !rejected
+                    ? `Sold ${sellItem.name} x${amountSold}`
+                    : `Sold ${sellItem.name} x${amountSold}; requested ${requestedAmount}`,
+                phase: quantity.complete && !rejected ? 'completion' : 'observation',
+                reason: quantity.complete && !rejected
+                    ? undefined
+                    : rejected ? 'rejected' : quantity.partial ? 'partial_fill' : failure,
+            };
+        };
 
         for (const stepAmount of sellSteps) {
             const countBefore = getTotalCount(this.sdk.getState()?.shop.playerItems ?? []);
 
             const result = await this.sdk.sendShopSell(sellItem.slot, stepAmount);
             if (!result.success) {
-                const totalSold = totalCountBefore - getTotalCount(this.sdk.getState()?.shop.playerItems ?? []);
-                if (totalSold > 0) {
-                    return { success: true, message: `Sold ${sellItem.name} x${totalSold} (wanted ${amount})`, amountSold: totalSold };
-                }
-                return { success: false, message: result.message };
+                const failed = outcome('dispatch_failed');
+                if (failed.amountSold === 0) failed.message = result.message;
+                return failed;
             }
 
             try {
                 const finalState = await this.sdk.waitForCondition(state => {
                     for (const msg of state.gameMessages) {
-                        if (msg.tick > msgBaseline) {
+                        if (isMessageAfterBaseline(msg, msgBaseline)) {
                             const text = msg.text.toLowerCase();
                             if (text.includes("can't sell this item")) {
                                 return true;
@@ -1130,35 +1272,38 @@ export class BotActions {
                 }, 5000);
 
                 for (const msg of finalState.gameMessages) {
-                    if (msg.tick > msgBaseline) {
+                    if (isMessageAfterBaseline(msg, msgBaseline)) {
                         const text = msg.text.toLowerCase();
                         if (text.includes("can't sell this item to this shop")) {
-                            return { success: false, message: `Shop doesn't buy ${sellItem.name}`, rejected: true };
+                            const rejected = outcome('rejected', true);
+                            rejected.message = `Shop doesn't buy ${sellItem.name}`;
+                            return rejected;
                         }
                         if (text.includes("can't sell this item to a shop")) {
-                            return { success: false, message: `Cannot sell ${sellItem.name} to any shop`, rejected: true };
+                            const rejected = outcome('rejected', true);
+                            rejected.message = `Cannot sell ${sellItem.name} to any shop`;
+                            return rejected;
                         }
                         if (text.includes("can't sell this item")) {
-                            return { success: false, message: `${sellItem.name} is not tradeable`, rejected: true };
+                            const rejected = outcome('rejected', true);
+                            rejected.message = `${sellItem.name} is not tradeable`;
+                            return rejected;
                         }
                     }
                 }
             } catch {
-                const totalSold = totalCountBefore - getTotalCount(this.sdk.getState()?.shop.playerItems ?? []);
-                if (totalSold > 0) {
-                    return { success: true, message: `Sold ${sellItem.name} x${totalSold} (wanted ${amount})`, amountSold: totalSold };
-                }
-                return { success: false, message: `Failed to sell ${sellItem.name} (timeout)` };
+                return outcome('timeout');
             }
         }
 
-        const totalCountAfter = getTotalCount(this.sdk.getState()?.shop.playerItems ?? []);
-        const totalSold = totalCountBefore - totalCountAfter;
-
-        return { success: true, message: `Sold ${sellItem.name} x${totalSold}`, amountSold: totalSold };
+        return outcome();
     }
 
-    private async sellAllToShop(sellItem: ShopItem, startTick: number, msgBaseline: number): Promise<ShopSellResult> {
+    private async sellAllToShop(
+        sellItem: ShopItem,
+        requestedAmount: number,
+        msgBaseline: ReturnType<typeof captureMessageBaseline>,
+    ): Promise<ShopSellResult> {
         let totalSold = 0;
 
         const getTotalCount = (playerItems: ShopItem[]) => {
@@ -1188,7 +1333,7 @@ export class BotActions {
             try {
                 const finalState = await this.sdk.waitForCondition(s => {
                     for (const msg of s.gameMessages) {
-                        if (msg.tick > msgBaseline) {
+                        if (isMessageAfterBaseline(msg, msgBaseline)) {
                             if (msg.text.toLowerCase().includes("can't sell this item")) {
                                 return true;
                             }
@@ -1200,24 +1345,30 @@ export class BotActions {
                 }, 3000);
 
                 for (const msg of finalState.gameMessages) {
-                    if (msg.tick > msgBaseline) {
+                    if (isMessageAfterBaseline(msg, msgBaseline)) {
                         const text = msg.text.toLowerCase();
                         if (text.includes("can't sell this item to this shop")) {
                             return {
-                                success: totalSold > 0,
-                                message: totalSold > 0
-                                    ? `Sold ${sellItem.name} x${totalSold}, then shop stopped buying`
-                                    : `Shop doesn't buy ${sellItem.name}`,
+                                success: false,
+                                message: `Sold ${sellItem.name} x${totalSold}; requested ${requestedAmount}`,
+                                requestedAmount,
                                 amountSold: totalSold,
-                                rejected: true
+                                partial: totalSold > 0,
+                                rejected: true,
+                                phase: 'observation',
+                                reason: 'rejected',
                             };
                         }
                         if (text.includes("can't sell this item")) {
                             return {
                                 success: false,
                                 message: `${sellItem.name} cannot be sold`,
+                                requestedAmount,
                                 amountSold: totalSold,
-                                rejected: true
+                                partial: totalSold > 0,
+                                rejected: true,
+                                phase: 'observation',
+                                reason: 'rejected',
                             };
                         }
                     }
@@ -1237,10 +1388,29 @@ export class BotActions {
         }
 
         if (totalSold === 0) {
-            return { success: false, message: `Failed to sell any ${sellItem.name}` };
+            return {
+                success: false,
+                message: `Failed to sell any ${sellItem.name}`,
+                requestedAmount,
+                amountSold: 0,
+                partial: false,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
 
-        return { success: true, message: `Sold ${sellItem.name} x${totalSold}`, amountSold: totalSold };
+        const quantity = classifyQuantity(requestedAmount, totalSold);
+        return {
+            success: quantity.complete,
+            message: quantity.complete
+                ? `Sold ${sellItem.name} x${totalSold}`
+                : `Sold ${sellItem.name} x${totalSold}; requested ${requestedAmount}`,
+            requestedAmount,
+            amountSold: totalSold,
+            partial: quantity.partial,
+            phase: quantity.complete ? 'completion' : 'observation',
+            reason: quantity.complete ? undefined : 'partial_fill',
+        };
     }
 
     // ============ Porcelain: Bank Actions ============
@@ -1395,31 +1565,71 @@ export class BotActions {
     async depositItem(target: InventoryItem | string | RegExp, amount: number = -1): Promise<BankDepositResult> {
         const state = this.sdk.getState();
         if (!state?.interface?.isOpen) {
-            return { success: false, message: 'Bank is not open', reason: 'bank_not_open' };
+            return {
+                success: false,
+                message: 'Bank is not open',
+                phase: 'validation',
+                reason: 'bank_not_open',
+            };
         }
 
         const item = this.helpers.resolveInventoryItem(target, /./);
         if (!item) {
-            return { success: false, message: `Item not found in inventory: ${target}`, reason: 'item_not_found' };
+            return {
+                success: false,
+                message: `Item not found in inventory: ${target}`,
+                phase: 'validation',
+                reason: 'item_not_found',
+            };
         }
 
         const countBefore = state.inventory.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0);
-
-        await this.sdk.sendBankDeposit(item.slot, amount);
+        const requestedAmount = amount === -1 ? countBefore : Math.max(1, Math.floor(amount));
+        const dispatch = await this.sdk.sendBankDeposit(item.slot, amount);
+        if (!dispatch.success) {
+            return {
+                success: false,
+                message: dispatch.message,
+                requestedAmount,
+                amountDeposited: 0,
+                partial: false,
+                phase: 'dispatch',
+                reason: 'dispatch_failed',
+            };
+        }
 
         try {
-            await this.sdk.waitForCondition(s => {
+            const finalState = await this.sdk.waitForCondition(s => {
                 const countNow = s.inventory.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0);
                 return countNow < countBefore;
             }, 5000);
 
-            const finalState = this.sdk.getState();
-            const countAfter = finalState?.inventory.filter(i => i.id === item.id).reduce((sum, i) => sum + i.count, 0) ?? 0;
-            const amountDeposited = countBefore - countAfter;
-
-            return { success: true, message: `Deposited ${item.name} x${amountDeposited}`, amountDeposited };
+            const countAfter = finalState.inventory
+                .filter(i => i.id === item.id)
+                .reduce((sum, i) => sum + i.count, 0);
+            const amountDeposited = Math.max(0, countBefore - countAfter);
+            const quantity = classifyQuantity(requestedAmount, amountDeposited);
+            return {
+                success: quantity.complete,
+                message: quantity.complete
+                    ? `Deposited ${item.name} x${amountDeposited}`
+                    : `Deposited ${item.name} x${amountDeposited}; requested ${requestedAmount}`,
+                requestedAmount,
+                amountDeposited,
+                partial: quantity.partial,
+                phase: quantity.complete ? 'completion' : 'observation',
+                reason: quantity.complete ? undefined : 'partial_fill',
+            };
         } catch {
-            return { success: false, message: `Timeout waiting for ${item.name} to be deposited`, reason: 'timeout' };
+            return {
+                success: false,
+                message: `Timeout waiting for ${item.name} to be deposited`,
+                requestedAmount,
+                amountDeposited: 0,
+                partial: false,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
     }
 
@@ -1427,44 +1637,78 @@ export class BotActions {
     async withdrawItem(target: BankItem | string | RegExp | number, amount: number = 1): Promise<BankWithdrawResult> {
         const state = this.sdk.getState();
         if (!state?.interface?.isOpen) {
-            return { success: false, message: 'Bank is not open', reason: 'bank_not_open' };
+            return {
+                success: false,
+                message: 'Bank is not open',
+                phase: 'validation',
+                reason: 'bank_not_open',
+            };
         }
 
-        let bankSlot: number;
+        let bankItem: BankItem | undefined;
         if (typeof target === 'number') {
-            bankSlot = target;
+            bankItem = state.bank.items.find(item => item.slot === target);
         } else if (typeof target === 'object' && 'slot' in target) {
-            bankSlot = target.slot;
+            bankItem = state.bank.items.find(item => item.slot === target.slot) ?? target;
         } else {
-            const found = this.sdk.findBankItem(target);
-            if (!found) {
-                return { success: false, message: `Bank item not found: ${target}`, reason: 'item_not_found' };
-            }
-            bankSlot = found.slot;
+            bankItem = this.sdk.findBankItem(target) ?? undefined;
+        }
+        if (!bankItem) {
+            return {
+                success: false,
+                message: `Bank item not found: ${target}`,
+                phase: 'validation',
+                reason: 'item_not_found',
+            };
         }
 
-        const invCountBefore = state.inventory.length;
-
-        await this.sdk.sendBankWithdraw(bankSlot, amount);
+        const countBefore = countInventoryItem(state.inventory, bankItem.id);
+        const requestedAmount = amount === -1 ? bankItem.count : Math.max(1, Math.floor(amount));
+        const dispatch = await this.sdk.sendBankWithdraw(bankItem.slot, amount);
+        if (!dispatch.success) {
+            return {
+                success: false,
+                message: dispatch.message,
+                requestedAmount,
+                amountWithdrawn: 0,
+                partial: false,
+                phase: 'dispatch',
+                reason: 'dispatch_failed',
+            };
+        }
 
         try {
-            await this.sdk.waitForCondition(s => {
-                return s.inventory.length > invCountBefore ||
-                       s.inventory.some(i => {
-                           const before = state.inventory.find(bi => bi.slot === i.slot);
-                           return before && i.count > before.count;
-                       });
+            const finalState = await this.sdk.waitForCondition(s => {
+                return countInventoryItem(s.inventory, bankItem!.id) > countBefore;
             }, 5000);
-
-            const finalInv = this.sdk.getInventory();
-            const newItem = finalInv.find(i => {
-                const before = state.inventory.find(bi => bi.slot === i.slot);
-                return !before || i.count > before.count;
-            });
-
-            return { success: true, message: `Withdrew item from bank slot ${bankSlot}`, item: newItem };
+            const amountWithdrawn = Math.max(
+                0,
+                countInventoryItem(finalState.inventory, bankItem.id) - countBefore,
+            );
+            const quantity = classifyQuantity(requestedAmount, amountWithdrawn);
+            const newItem = finalState.inventory.find(item => item.id === bankItem.id);
+            return {
+                success: quantity.complete,
+                message: quantity.complete
+                    ? `Withdrew ${bankItem.name} x${amountWithdrawn}`
+                    : `Withdrew ${bankItem.name} x${amountWithdrawn}; requested ${requestedAmount}`,
+                item: newItem,
+                requestedAmount,
+                amountWithdrawn,
+                partial: quantity.partial,
+                phase: quantity.complete ? 'completion' : 'observation',
+                reason: quantity.complete ? undefined : 'partial_fill',
+            };
         } catch {
-            return { success: false, message: `Timeout waiting for item to be withdrawn`, reason: 'timeout' };
+            return {
+                success: false,
+                message: `Timeout waiting for ${bankItem.name} to be withdrawn`,
+                requestedAmount,
+                amountWithdrawn: 0,
+                partial: false,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
     }
 
@@ -1813,217 +2057,112 @@ export class BotActions {
 
         const knife = this.sdk.findInventoryItem(/knife/i);
         if (!knife) {
-            return { success: false, message: 'No knife in inventory' };
+            return { success: false, message: 'No knife in inventory', phase: 'validation', reason: 'no_knife' };
         }
 
         const logs = this.sdk.findInventoryItem(/logs/i);
         if (!logs) {
-            return { success: false, message: 'No logs in inventory' };
+            return { success: false, message: 'No logs in inventory', phase: 'validation', reason: 'no_logs' };
         }
 
-        // Check if we're using oak or higher-tier logs (affects button order)
-        const isOakOrHigherLogs = /oak|willow|maple|yew|magic/i.test(logs.name);
-
+        const higherTierLogs = /oak|willow|maple|yew|magic/i.test(logs.name);
+        const requestedProduct = resolveFletchProduct(product ?? (higherTierLogs ? 'shortbow' : undefined));
+        if (!requestedProduct) {
+            return {
+                success: false,
+                message: `Unknown fletching product "${product}"`,
+                phase: 'validation',
+                reason: 'no_matching_option',
+            };
+        }
+        const inventoryBefore = [...this.sdk.getInventory()];
         const fletchingBefore = this.sdk.getSkill('Fletching')?.experience || 0;
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
+        const msgBaseline = captureMessageBaseline(this.sdk.getState());
 
-        // Use knife on logs to open fletching dialog
         const result = await this.sdk.sendUseItemOnItem(knife.slot, logs.slot);
         if (!result.success) {
-            return { success: false, message: result.message };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
-        // Wait for dialog/interface to open
         try {
-            await this.sdk.waitForCondition(
-                s => s.dialog.isOpen || s.interface?.isOpen,
-                5000
-            );
+            await this.sdk.waitForCondition(s => s.dialog.isOpen || s.interface?.isOpen, 5000);
         } catch {
-            return { success: false, message: 'Fletching dialog did not open' };
-        }
-
-        // Handle product selection and crafting
-        const MAX_ATTEMPTS = 30;
-        let buttonClicked = false;
-
-        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-            const state = this.sdk.getState();
-            if (!state) {
-                return { success: false, message: 'Lost game state' };
-            }
-
-            // Check if XP was gained (success!)
-            const currentXp = state.skills.find(s => s.name === 'Fletching')?.experience || 0;
-            if (currentXp > fletchingBefore) {
-                const craftedProduct = this.sdk.findInventoryItem(/shortbow|longbow|arrow shaft|stock/i);
-                return {
-                    success: true,
-                    message: 'Fletched logs successfully',
-                    xpGained: currentXp - fletchingBefore,
-                    product: craftedProduct || undefined
-                };
-            }
-
-            // Handle interface (make-x style)
-            if (state.interface?.isOpen) {
-                // Try to find product by text in options
-                let targetIndex = 1;
-                if (product) {
-                    const productLower = product.toLowerCase();
-                    const matchingOption = state.interface.options.find(o =>
-                        o.text.toLowerCase().includes(productLower)
-                    );
-                    if (matchingOption) {
-                        targetIndex = matchingOption.index;
-                    }
-                }
-
-                if (!buttonClicked) {
-                    await this.sdk.sendClickInterfaceOption(targetIndex);
-                    buttonClicked = true;
-                } else if (state.interface.options.length > 0 && state.interface.options[0]) {
-                    await this.sdk.sendClickInterfaceOption(0);
-                }
-                await this.sdk.waitForTicks(1);
-                continue;
-            }
-
-            // Handle dialog - use allComponents to find the right button
-            if (state.dialog.isOpen) {
-                if (!buttonClicked && product && state.dialog.allComponents) {
-                    // Find the button that matches our product by looking at allComponents text
-                    const productLower = product.toLowerCase();
-
-                    // Build a mapping of product text to button index
-                    // allComponents contains both text labels and "Ok" buttons
-                    // We need to find which "Ok" button corresponds to our product
-
-                    // Look for a component whose text matches the product
-                    const matchingComponents = state.dialog.allComponents.filter(c => {
-                        const text = c.text.toLowerCase();
-                        // Match patterns like "shortbow", "longbow", "arrow shaft"
-                        if (productLower.includes('short') && text.includes('shortbow')) return true;
-                        if (productLower.includes('long') && text.includes('longbow')) return true;
-                        if (productLower.includes('arrow') && text.includes('arrow')) return true;
-                        if (productLower.includes('shaft') && text.includes('shaft')) return true;
-                        if (productLower.includes('stock') && text.includes('stock')) return true;
-                        // Generic match
-                        return text.includes(productLower);
-                    });
-
-                    if (matchingComponents.length > 0) {
-                        // Found a matching text component - now find the associated Ok button
-                        // The Ok buttons in dialog.options should correspond to the products
-                        // Try to find the index by matching component IDs or order
-
-                        // Get all Ok buttons from options
-                        const okButtons = state.dialog.options.filter(o =>
-                            o.text.toLowerCase() === 'ok'
-                        );
-
-                        if (okButtons.length > 0) {
-                            // Try to determine which Ok button to click based on product type
-                            // Button order depends on log type:
-                            // - Regular logs: [Arrow shafts, Shortbow, Longbow] - 3 main products
-                            // - Oak/higher logs: [Shortbow, Longbow] - 2 main products (no arrow shafts option)
-                            let okIndex = 0; // Default to first
-
-                            if (productLower.includes('short')) {
-                                if (isOakOrHigherLogs) {
-                                    // Oak/higher logs: Shortbow is first (index 0)
-                                    okIndex = 0;
-                                } else {
-                                    // Regular logs: Shortbow is second (index 1, after arrow shafts)
-                                    okIndex = Math.min(1, okButtons.length - 1);
-                                }
-                            } else if (productLower.includes('long')) {
-                                if (isOakOrHigherLogs) {
-                                    // Oak/higher logs: Longbow is second (index 1)
-                                    okIndex = Math.min(1, okButtons.length - 1);
-                                } else {
-                                    // Regular logs: Longbow is third (index 2)
-                                    okIndex = Math.min(2, okButtons.length - 1);
-                                }
-                            } else if (productLower.includes('stock')) {
-                                okIndex = Math.min(3, okButtons.length - 1);
-                            }
-                            // arrow/shaft stays at 0
-
-                            const targetButton = okButtons[okIndex];
-                            if (targetButton) {
-                                await this.sdk.sendClickDialog(targetButton.index);
-                                buttonClicked = true;
-                                await this.sdk.waitForTicks(1);
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                // Fallback: use index-based approach if we couldn't match by text
-                if (!buttonClicked) {
-                    // Determine fallback index based on product keyword and log type
-                    let targetButtonIndex = 1; // Default: first option
-                    if (product) {
-                        const productLower = product.toLowerCase();
-                        if (productLower.includes('short')) {
-                            // Oak/higher: shortbow is button 1; Regular: button 2
-                            targetButtonIndex = isOakOrHigherLogs ? 1 : 2;
-                        } else if (productLower.includes('long')) {
-                            // Oak/higher: longbow is button 2; Regular: button 3
-                            targetButtonIndex = isOakOrHigherLogs ? 2 : 3;
-                        } else if (productLower.includes('stock')) {
-                            targetButtonIndex = 4;
-                        }
-                        // arrow/shaft stays at 1
-                    }
-
-                    if (state.dialog.options.length >= targetButtonIndex) {
-                        await this.sdk.sendClickDialog(targetButtonIndex);
-                        buttonClicked = true;
-                        await this.sdk.waitForTicks(1);
-                        continue;
-                    }
-                }
-
-                // If we already clicked or don't have enough options, click continue/first
-                if (state.dialog.options.length > 0 && state.dialog.options[0]) {
-                    await this.sdk.sendClickDialog(state.dialog.options[0].index);
-                } else {
-                    await this.sdk.sendClickDialog(0);
-                }
-                await this.sdk.waitForTicks(1);
-                continue;
-            }
-
-            // Check for failure messages
-            for (const msg of state.gameMessages) {
-                if (msg.tick > msgBaseline) {
-                    const text = msg.text.toLowerCase();
-                    if (text.includes("need a higher") || text.includes("level to")) {
-                        return { success: false, message: 'Fletching level too low' };
-                    }
-                }
-            }
-
-            await this.sdk.waitForTicks(1);
-        }
-
-        // Final XP check
-        const finalXp = this.sdk.getSkill('Fletching')?.experience || 0;
-        if (finalXp > fletchingBefore) {
-            const craftedProduct = this.sdk.findInventoryItem(/shortbow|longbow|arrow shaft|stock/i);
             return {
-                success: true,
-                message: 'Fletched logs successfully',
-                xpGained: finalXp - fletchingBefore,
-                product: craftedProduct || undefined
+                success: false,
+                message: 'Fletching dialog did not open',
+                phase: 'observation',
+                reason: 'interface_not_opened',
             };
         }
 
-        return { success: false, message: 'Fletching timed out' };
+        const state = this.sdk.getState();
+        if (!state) {
+            return { success: false, message: 'Lost game state', phase: 'observation', reason: 'timeout' };
+        }
+        const position = productPosition(requestedProduct, higherTierLogs);
+        let selection: ActionResult | null = null;
+        if (state.interface?.isOpen) {
+            const option = resolveInterfaceOption(state.interface.options, requestedProduct.optionPattern)
+                ?? state.interface.options[position]
+                ?? null;
+            selection = option ? await this.sdk.clickInterfaceOption(option) : null;
+        } else if (state.dialog.isOpen) {
+            const textOption = state.dialog.options.find(option => {
+                requestedProduct.optionPattern.lastIndex = 0;
+                return requestedProduct.optionPattern.test(option.text);
+            });
+            const okOptions = state.dialog.options.filter(option => /^ok$/i.test(option.text));
+            const option = textOption ?? okOptions[position] ?? null;
+            selection = option ? await this.sdk.sendClickDialog(option.index) : null;
+        }
+        if (!selection?.success) {
+            return {
+                success: false,
+                message: selection?.message ?? `No option for ${requestedProduct.name}`,
+                phase: 'dispatch',
+                reason: selection ? 'dispatch_failed' : 'no_matching_option',
+            };
+        }
+
+        let levelTooLow = false;
+        try {
+            const finalState = await this.sdk.waitForCondition(current => {
+                levelTooLow = current.gameMessages.some(message =>
+                    isMessageAfterBaseline(message, msgBaseline) && /need a higher|level to/i.test(message.text)
+                );
+                const xp = current.skills.find(skill => skill.name === 'Fletching')?.experience || 0;
+                return levelTooLow ||
+                    (xp > fletchingBefore &&
+                        findProducedItem(inventoryBefore, current.inventory, requestedProduct) !== null);
+            }, 10000);
+            if (levelTooLow) {
+                return { success: false, message: 'Fletching level too low', phase: 'observation', reason: 'level_too_low' };
+            }
+            const xp = finalState.skills.find(skill => skill.name === 'Fletching')?.experience || 0;
+            const produced = findProducedItem(inventoryBefore, finalState.inventory, requestedProduct);
+            if (xp > fletchingBefore && produced) {
+                return {
+                    success: true,
+                    message: `Fletched ${requestedProduct.name}`,
+                    phase: 'completion',
+                    xpGained: xp - fletchingBefore,
+                    product: produced,
+                };
+            }
+        } catch {
+            const current = this.sdk.getState();
+            const xp = current?.skills.find(skill => skill.name === 'Fletching')?.experience || 0;
+            if (xp > fletchingBefore) {
+                return {
+                    success: false,
+                    message: `Fletching XP increased, but requested ${requestedProduct.name} was not produced`,
+                    phase: 'observation',
+                    reason: 'wrong_product',
+                    xpGained: xp - fletchingBefore,
+                };
+            }
+        }
+        return { success: false, message: 'Fletching timed out', phase: 'observation', reason: 'timeout' };
     }
 
     /** Craft leather into armour using needle and thread. */
@@ -2032,158 +2171,123 @@ export class BotActions {
 
         const needle = this.sdk.findInventoryItem(/needle/i);
         if (!needle) {
-            return { success: false, message: 'No needle in inventory', reason: 'no_needle' };
+            return { success: false, message: 'No needle in inventory', phase: 'validation', reason: 'no_needle' };
         }
 
         const leather = this.sdk.findInventoryItem(/^leather$/i);
         if (!leather) {
-            return { success: false, message: 'No leather in inventory', reason: 'no_leather' };
+            return { success: false, message: 'No leather in inventory', phase: 'validation', reason: 'no_leather' };
         }
 
         const thread = this.sdk.findInventoryItem(/thread/i);
         if (!thread) {
-            return { success: false, message: 'No thread in inventory', reason: 'no_thread' };
+            return { success: false, message: 'No thread in inventory', phase: 'validation', reason: 'no_thread' };
         }
 
+        const requestedProduct = resolveLeatherProduct(product);
+        if (!requestedProduct) {
+            return {
+                success: false,
+                message: `Unknown leather product "${product}"`,
+                phase: 'validation',
+                reason: 'no_matching_option',
+            };
+        }
+        const inventoryBefore = [...this.sdk.getInventory()];
         const craftingBefore = this.sdk.getSkill('Crafting')?.experience || 0;
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
+        const msgBaseline = captureMessageBaseline(this.sdk.getState());
 
-        // Use needle on leather to open crafting interface
         const result = await this.sdk.sendUseItemOnItem(needle.slot, leather.slot);
         if (!result.success) {
-            return { success: false, message: result.message };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
-        // Wait for interface/dialog to open
         try {
-            await this.sdk.waitForCondition(
-                s => s.dialog.isOpen || s.interface?.isOpen,
-                10000
-            );
+            await this.sdk.waitForCondition(s => s.dialog.isOpen || s.interface?.isOpen, 10000);
         } catch {
-            return { success: false, message: 'Crafting interface did not open', reason: 'interface_not_opened' };
-        }
-
-        // Handle product selection and crafting
-        const MAX_ATTEMPTS = 50;
-
-        for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-            const state = this.sdk.getState();
-            if (!state) {
-                return { success: false, message: 'Lost game state' };
-            }
-
-            // Check if XP was gained (success!)
-            const currentXp = state.skills.find(s => s.name === 'Crafting')?.experience || 0;
-            if (currentXp > craftingBefore) {
-                return {
-                    success: true,
-                    message: 'Crafted leather item successfully',
-                    xpGained: currentXp - craftingBefore,
-                    itemsCrafted: 1
-                };
-            }
-
-            // Handle interface (leather crafting interface id=2311)
-            if (state.interface?.isOpen) {
-                if (product) {
-                    // Try to find matching option by text
-                    const productOption = state.interface.options.find(o =>
-                        o.text.toLowerCase().includes(product.toLowerCase())
-                    );
-                    if (productOption) {
-                        await this.sdk.sendClickInterfaceOption(productOption.index);
-                        await this.sdk.waitForTicks(1);
-                        continue;
-                    }
-                }
-
-                // Leather crafting interface (2311) - options are 1-indexed in state but
-                // sendClickInterfaceOption uses 0-based array indices.
-                // option.index 1 = leather body (lvl 14), array idx 0
-                // option.index 2 = leather gloves (lvl 1), array idx 1
-                // option.index 3 = leather chaps (lvl 18), array idx 2
-                if (state.interface.interfaceId === 2311) {
-                    // Map product names to array indices (0-based)
-                    let optionIndex = 1; // Default: gloves (array idx 1, lowest level requirement)
-                    if (product) {
-                        const productLower = product.toLowerCase();
-                        if (productLower.includes('body') || productLower.includes('armour')) {
-                            optionIndex = 0; // array idx 0 -> option.index 1 = body
-                        } else if (productLower.includes('chaps') || productLower.includes('legs')) {
-                            optionIndex = 2; // array idx 2 -> option.index 3 = chaps
-                        } else if (productLower.includes('glove') || productLower.includes('vamb')) {
-                            optionIndex = 1; // array idx 1 -> option.index 2 = gloves
-                        }
-                    }
-                    await this.sdk.sendClickInterfaceOption(optionIndex);
-                } else if (state.interface.options.length > 0 && state.interface.options[0]) {
-                    await this.sdk.sendClickInterfaceOption(0);
-                }
-                await this.sdk.waitForTicks(1);
-                continue;
-            }
-
-            // Handle dialog
-            if (state.dialog.isOpen) {
-                const craftOption = state.dialog.options.find(o =>
-                    /glove|make|craft|leather|body|chaps/i.test(o.text)
-                );
-                if (craftOption) {
-                    await this.sdk.sendClickDialog(craftOption.index);
-                } else if (state.dialog.options.length > 0 && state.dialog.options[0]) {
-                    await this.sdk.sendClickDialog(state.dialog.options[0].index);
-                } else {
-                    await this.sdk.sendClickDialog(0);
-                }
-                await this.sdk.waitForTicks(1);
-                continue;
-            }
-
-            // Check for failure messages
-            for (const msg of state.gameMessages) {
-                if (msg.tick > msgBaseline) {
-                    const text = msg.text.toLowerCase();
-                    if (text.includes("need a crafting level") || text.includes("level to")) {
-                        return { success: false, message: 'Crafting level too low', reason: 'level_too_low' };
-                    }
-                    if (text.includes("don't have") && text.includes("thread")) {
-                        return { success: false, message: 'Out of thread', reason: 'no_thread' };
-                    }
-                }
-            }
-
-            // Check if leather is gone (possibly consumed)
-            const currentLeather = this.sdk.findInventoryItem(/^leather$/i);
-            if (!currentLeather) {
-                // Check XP one more time
-                const finalXp = this.sdk.getSkill('Crafting')?.experience || 0;
-                if (finalXp > craftingBefore) {
-                    return {
-                        success: true,
-                        message: 'Crafted leather item successfully',
-                        xpGained: finalXp - craftingBefore,
-                        itemsCrafted: 1
-                    };
-                }
-            }
-
-            await this.sdk.waitForTicks(1);
-        }
-
-        // Final XP check
-        const finalXp = this.sdk.getSkill('Crafting')?.experience || 0;
-        if (finalXp > craftingBefore) {
             return {
-                success: true,
-                message: 'Crafted leather item successfully',
-                xpGained: finalXp - craftingBefore,
-                itemsCrafted: 1
+                success: false,
+                message: 'Crafting interface did not open',
+                phase: 'observation',
+                reason: 'interface_not_opened',
             };
         }
 
-        return { success: false, message: 'Crafting timed out', reason: 'timeout' };
+        const state = this.sdk.getState();
+        if (!state) {
+            return { success: false, message: 'Lost game state', phase: 'observation', reason: 'timeout' };
+        }
+        const position = productPosition(requestedProduct, false);
+        let selection: ActionResult | null = null;
+        if (state.interface?.isOpen) {
+            const option = resolveInterfaceOption(state.interface.options, requestedProduct.optionPattern)
+                ?? state.interface.options[position]
+                ?? null;
+            selection = option ? await this.sdk.clickInterfaceOption(option) : null;
+        } else if (state.dialog.isOpen) {
+            const option = state.dialog.options.find(candidate => {
+                requestedProduct.optionPattern.lastIndex = 0;
+                return requestedProduct.optionPattern.test(candidate.text);
+            }) ?? state.dialog.options[position] ?? null;
+            selection = option ? await this.sdk.sendClickDialog(option.index) : null;
+        }
+        if (!selection?.success) {
+            return {
+                success: false,
+                message: selection?.message ?? `No option for ${requestedProduct.name}`,
+                phase: 'dispatch',
+                reason: selection ? 'dispatch_failed' : 'no_matching_option',
+            };
+        }
+
+        let failure: 'level_too_low' | 'no_thread' | null = null;
+        try {
+            const finalState = await this.sdk.waitForCondition(current => {
+                for (const message of current.gameMessages) {
+                    if (!isMessageAfterBaseline(message, msgBaseline)) continue;
+                    if (/need a crafting level|level to/i.test(message.text)) failure = 'level_too_low';
+                    if (/don't have.*thread/i.test(message.text)) failure = 'no_thread';
+                }
+                const xp = current.skills.find(skill => skill.name === 'Crafting')?.experience || 0;
+                return failure !== null ||
+                    (xp > craftingBefore &&
+                        findProducedItem(inventoryBefore, current.inventory, requestedProduct) !== null);
+            }, 10000);
+            if (failure) {
+                return {
+                    success: false,
+                    message: failure === 'no_thread' ? 'Out of thread' : 'Crafting level too low',
+                    phase: 'observation',
+                    reason: failure,
+                };
+            }
+            const xp = finalState.skills.find(skill => skill.name === 'Crafting')?.experience || 0;
+            const produced = findProducedItem(inventoryBefore, finalState.inventory, requestedProduct);
+            if (xp > craftingBefore && produced) {
+                return {
+                    success: true,
+                    message: `Crafted ${requestedProduct.name}`,
+                    phase: 'completion',
+                    xpGained: xp - craftingBefore,
+                    itemsCrafted: countInventoryItem(finalState.inventory, requestedProduct.inventoryPattern) -
+                        countInventoryItem(inventoryBefore, requestedProduct.inventoryPattern),
+                    product: produced,
+                };
+            }
+        } catch {
+            const current = this.sdk.getState();
+            const xp = current?.skills.find(skill => skill.name === 'Crafting')?.experience || 0;
+            if (xp > craftingBefore) {
+                return {
+                    success: false,
+                    message: `Crafting XP increased, but requested ${requestedProduct.name} was not produced`,
+                    phase: 'observation',
+                    reason: 'wrong_product',
+                    xpGained: xp - craftingBefore,
+                };
+            }
+        }
+        return { success: false, message: 'Crafting timed out', phase: 'observation', reason: 'timeout' };
     }
 
     // ============ Smithing ============
@@ -2411,18 +2515,18 @@ export class BotActions {
     /**
      * Interact with a nearby location object (rock, fishing spot, furnace, etc.).
      * Walks to the target first (handling doors), sends the interaction, then waits
-     * for an effect (animation, dialog, interface) or detects failure when the player
-     * has been idle for 2 ticks with nothing happening.
+     * for observable effect evidence until a real deadline.
      * @param target - NearbyLoc object or name string/regex to find
      * @param option - Option index or name regex to match (default: 1, the first option)
      */
     async interactLoc(
         target: NearbyLoc | string | RegExp,
         option: number | string | RegExp = 1,
+        wait: InteractionWaitOptions = {},
     ): Promise<InteractLocResult> {
         const resolvedLoc = this.helpers.resolveLocation(target, /./);
         return this.helpers.withDoorRetry(
-            () => this._interactLocOnce(target, option),
+            () => this._interactLocOnce(target, option, wait),
             (r) => r.reason === 'cant_reach',
             2,
             resolvedLoc ? { x: resolvedLoc.x, z: resolvedLoc.z } : undefined
@@ -2432,12 +2536,18 @@ export class BotActions {
     private async _interactLocOnce(
         target: NearbyLoc | string | RegExp,
         option: number | string | RegExp = 1,
+        wait: InteractionWaitOptions = {},
     ): Promise<InteractLocResult> {
         await this.dismissBlockingUI();
 
         const loc = this.helpers.resolveLocation(target, /./);
         if (!loc) {
-            return { success: false, message: `Location not found: ${target}`, reason: 'loc_not_found' };
+            return {
+                success: false,
+                message: `Location not found: ${target}`,
+                phase: 'validation',
+                reason: 'loc_not_found',
+            };
         }
 
         // Resolve option index
@@ -2448,7 +2558,12 @@ export class BotActions {
             const regex = typeof option === 'string' ? new RegExp(option, 'i') : option;
             const match = loc.optionsWithIndex.find(o => regex.test(o.text));
             if (!match) {
-                return { success: false, message: `No matching option on ${loc.name}`, reason: 'no_matching_option' };
+                return {
+                    success: false,
+                    message: `No matching option on ${loc.name}`,
+                    phase: 'validation',
+                    reason: 'no_matching_option',
+                };
             }
             opIndex = match.opIndex;
         }
@@ -2457,7 +2572,12 @@ export class BotActions {
         if (loc.distance > 2) {
             const walkResult = await this.walkTo(loc.x, loc.z, 2);
             if (!walkResult.success) {
-                return { success: false, message: `Cannot reach ${loc.name}: ${walkResult.message}`, reason: 'cant_reach' };
+                return {
+                    success: false,
+                    message: `Cannot reach ${loc.name}: ${walkResult.message}`,
+                    phase: 'routing',
+                    reason: 'cant_reach',
+                };
             }
         }
 
@@ -2465,76 +2585,74 @@ export class BotActions {
         const locPattern = typeof target === 'object' ? new RegExp(loc.name, 'i') : target;
         const locNow = this.helpers.resolveLocation(locPattern, /./);
         if (!locNow) {
-            return { success: false, message: `${loc.name} no longer visible`, reason: 'loc_not_found' };
+            return {
+                success: false,
+                message: `${loc.name} no longer visible`,
+                phase: 'validation',
+                reason: 'loc_not_found',
+            };
         }
 
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
-        let lastMoveTick = startTick;
-        let lastX = this.sdk.getState()?.player?.x ?? 0;
-        let lastZ = this.sdk.getState()?.player?.z ?? 0;
-
+        const initialState = this.sdk.getState();
+        if (!initialState) {
+            return { success: false, message: 'No game state', phase: 'observation', reason: 'timeout' };
+        }
+        const baseline = captureInteractionBaseline(initialState);
         const result = await this.sdk.sendInteractLoc(locNow.x, locNow.z, locNow.id, opIndex);
         if (!result.success) {
-            return { success: false, message: result.message, reason: 'timeout' };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
         try {
             const finalState = await this.sdk.waitForCondition(state => {
-                // Check for can't-reach messages
-                for (const msg of state.gameMessages) {
-                    if (msg.tick > msgBaseline) {
-                        const text = msg.text.toLowerCase();
-                        if (text.includes("can't reach") || text.includes("cannot reach")) return true;
-                    }
-                }
+                const cantReach = state.gameMessages.some(message =>
+                    isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+                );
+                return cantReach || detectInteractionEvidence(state, baseline, wait) !== null;
+            }, wait.timeout ?? 5000);
 
-                // Success indicators
-                if (state.dialog.isOpen || state.interface?.isOpen) return true;
-                if (state.player && state.player.animId !== -1) return true;
-
-                // Track movement — if player moved, update last move tick
-                if (state.player && (state.player.x !== lastX || state.player.z !== lastZ)) {
-                    lastX = state.player.x;
-                    lastZ = state.player.z;
-                    lastMoveTick = state.tick;
-                }
-
-                // Player idle for 2+ ticks with nothing happening → give up
-                if (state.tick - lastMoveTick >= 2) return true;
-
-                return false;
-            }, 30000); // safety net only
-
-            if (this.helpers.checkCantReachMessage(msgBaseline)) {
-                return { success: false, message: `Can't reach ${locNow.name}`, reason: 'cant_reach' };
+            const cantReach = finalState.gameMessages.some(message =>
+                isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+            );
+            if (cantReach) {
+                return {
+                    success: false,
+                    message: `Can't reach ${locNow.name}`,
+                    phase: 'observation',
+                    reason: 'cant_reach',
+                };
             }
-
-            if (finalState.dialog.isOpen || finalState.interface?.isOpen ||
-                (finalState.player && finalState.player.animId !== -1)) {
-                return { success: true, message: `Interacted with ${locNow.name}` };
-            }
-
-            return { success: false, message: `Nothing happened interacting with ${locNow.name}`, reason: 'timeout' };
+            const evidence = detectInteractionEvidence(finalState, baseline, wait);
+            return {
+                success: true,
+                message: `Interacted with ${locNow.name} (${evidence})`,
+                phase: 'completion',
+                evidence: evidence ?? undefined,
+            };
         } catch {
-            return { success: false, message: `Timed out interacting with ${locNow.name}`, reason: 'timeout' };
+            return {
+                success: false,
+                message: `Timed out after ${wait.timeout ?? 5000}ms interacting with ${locNow.name}`,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
     }
 
     /**
      * Interact with a nearby NPC using a specified option (e.g. "Trade", "Pickpocket", "Fish").
      * Walks to the NPC first (handling doors), sends the interaction, then waits
-     * for an effect (animation, dialog, interface) or detects failure when the player
-     * has been idle for 2 ticks with nothing happening.
+     * for observable effect evidence until a real deadline.
      * @param target - NearbyNpc object or name string/regex to find
      * @param option - Option index or name regex to match (default: 1, the first option)
      */
     async interactNpc(
         target: NearbyNpc | string | RegExp,
         option: number | string | RegExp = 1,
+        wait: InteractionWaitOptions = {},
     ): Promise<InteractNpcResult> {
         return this.helpers.withDoorRetry(
-            () => this._interactNpcOnce(target, option),
+            () => this._interactNpcOnce(target, option, wait),
             (r) => r.reason === 'cant_reach'
         );
     }
@@ -2542,12 +2660,18 @@ export class BotActions {
     private async _interactNpcOnce(
         target: NearbyNpc | string | RegExp,
         option: number | string | RegExp = 1,
+        wait: InteractionWaitOptions = {},
     ): Promise<InteractNpcResult> {
         await this.dismissBlockingUI();
 
         const npc = this.helpers.resolveNpc(target);
         if (!npc) {
-            return { success: false, message: `NPC not found: ${target}`, reason: 'npc_not_found' };
+            return {
+                success: false,
+                message: `NPC not found: ${target}`,
+                phase: 'validation',
+                reason: 'npc_not_found',
+            };
         }
 
         // Resolve option index
@@ -2558,7 +2682,12 @@ export class BotActions {
             const regex = typeof option === 'string' ? new RegExp(option, 'i') : option;
             const match = npc.optionsWithIndex.find(o => regex.test(o.text));
             if (!match) {
-                return { success: false, message: `No matching option on ${npc.name}`, reason: 'no_matching_option' };
+                return {
+                    success: false,
+                    message: `No matching option on ${npc.name}`,
+                    phase: 'validation',
+                    reason: 'no_matching_option',
+                };
             }
             opIndex = match.opIndex;
         }
@@ -2567,7 +2696,12 @@ export class BotActions {
         if (npc.distance > 2) {
             const walkResult = await this.walkTo(npc.x, npc.z, 2);
             if (!walkResult.success) {
-                return { success: false, message: `Cannot reach ${npc.name}: ${walkResult.message}`, reason: 'cant_reach' };
+                return {
+                    success: false,
+                    message: `Cannot reach ${npc.name}: ${walkResult.message}`,
+                    phase: 'routing',
+                    reason: 'cant_reach',
+                };
             }
         }
 
@@ -2575,59 +2709,57 @@ export class BotActions {
         const npcPattern = typeof target === 'object' ? new RegExp(npc.name, 'i') : target;
         const npcNow = this.helpers.resolveNpc(npcPattern);
         if (!npcNow) {
-            return { success: false, message: `${npc.name} no longer visible`, reason: 'npc_not_found' };
+            return {
+                success: false,
+                message: `${npc.name} no longer visible`,
+                phase: 'validation',
+                reason: 'npc_not_found',
+            };
         }
 
-        const startTick = this.sdk.getState()?.tick || 0;
-        const msgBaseline = this.helpers.getMessageTick();
-        let lastMoveTick = startTick;
-        let lastX = this.sdk.getState()?.player?.x ?? 0;
-        let lastZ = this.sdk.getState()?.player?.z ?? 0;
-
+        const initialState = this.sdk.getState();
+        if (!initialState) {
+            return { success: false, message: 'No game state', phase: 'observation', reason: 'timeout' };
+        }
+        const baseline = captureInteractionBaseline(initialState);
         const result = await this.sdk.sendInteractNpc(npcNow.index, opIndex);
         if (!result.success) {
-            return { success: false, message: result.message, reason: 'timeout' };
+            return { success: false, message: result.message, phase: 'dispatch', reason: 'dispatch_failed' };
         }
 
         try {
             const finalState = await this.sdk.waitForCondition(state => {
-                // Check for can't-reach messages
-                for (const msg of state.gameMessages) {
-                    if (msg.tick > msgBaseline) {
-                        const text = msg.text.toLowerCase();
-                        if (text.includes("can't reach") || text.includes("cannot reach")) return true;
-                    }
-                }
+                const cantReach = state.gameMessages.some(message =>
+                    isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+                );
+                return cantReach || detectInteractionEvidence(state, baseline, wait) !== null;
+            }, wait.timeout ?? 5000);
 
-                // Success indicators
-                if (state.dialog.isOpen || state.interface?.isOpen) return true;
-                if (state.player && state.player.animId !== -1) return true;
-
-                // Track movement — if player moved, update last move tick
-                if (state.player && (state.player.x !== lastX || state.player.z !== lastZ)) {
-                    lastX = state.player.x;
-                    lastZ = state.player.z;
-                    lastMoveTick = state.tick;
-                }
-
-                // Player idle for 2+ ticks with nothing happening → give up
-                if (state.tick - lastMoveTick >= 2) return true;
-
-                return false;
-            }, 30000); // safety net only
-
-            if (this.helpers.checkCantReachMessage(msgBaseline)) {
-                return { success: false, message: `Can't reach ${npcNow.name}`, reason: 'cant_reach' };
+            const cantReach = finalState.gameMessages.some(message =>
+                isMessageAfterBaseline(message, baseline) && /can't reach|cannot reach/i.test(message.text)
+            );
+            if (cantReach) {
+                return {
+                    success: false,
+                    message: `Can't reach ${npcNow.name}`,
+                    phase: 'observation',
+                    reason: 'cant_reach',
+                };
             }
-
-            if (finalState.dialog.isOpen || finalState.interface?.isOpen ||
-                (finalState.player && finalState.player.animId !== -1)) {
-                return { success: true, message: `Interacted with ${npcNow.name}` };
-            }
-
-            return { success: false, message: `Nothing happened interacting with ${npcNow.name}`, reason: 'timeout' };
+            const evidence = detectInteractionEvidence(finalState, baseline, wait);
+            return {
+                success: true,
+                message: `Interacted with ${npcNow.name} (${evidence})`,
+                phase: 'completion',
+                evidence: evidence ?? undefined,
+            };
         } catch {
-            return { success: false, message: `Timed out interacting with ${npcNow.name}`, reason: 'timeout' };
+            return {
+                success: false,
+                message: `Timed out after ${wait.timeout ?? 5000}ms interacting with ${npcNow.name}`,
+                phase: 'observation',
+                reason: 'timeout',
+            };
         }
     }
 

--- a/sdk/crafting-products.ts
+++ b/sdk/crafting-products.ts
@@ -1,4 +1,4 @@
-import type { InventoryItem } from './types';
+import type { InterfaceOption, InventoryItem } from './types';
 import { countInventoryItem } from './action-reliability';
 
 export interface CraftProduct {
@@ -39,16 +39,6 @@ const FLETCH_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
             higherTierPosition: 1,
         },
     },
-    {
-        aliases: /stock/i,
-        product: {
-            name: 'crossbow stock',
-            optionPattern: /stock/i,
-            inventoryPattern: /stock/i,
-            regularPosition: 3,
-            higherTierPosition: 3,
-        },
-    },
 ];
 
 const LEATHER_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
@@ -62,12 +52,21 @@ const LEATHER_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
         },
     },
     {
-        aliases: /glove|vamb/i,
+        aliases: /glove/i,
         product: {
             name: 'leather gloves',
-            optionPattern: /glove|vamb/i,
+            optionPattern: /glove/i,
             inventoryPattern: /^leather gloves$/i,
             regularPosition: 1,
+        },
+    },
+    {
+        aliases: /boot/i,
+        product: {
+            name: 'leather boots',
+            optionPattern: /boot/i,
+            inventoryPattern: /^leather boots$/i,
+            regularPosition: 2,
         },
     },
     {
@@ -76,7 +75,34 @@ const LEATHER_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
             name: 'leather chaps',
             optionPattern: /chap|leg/i,
             inventoryPattern: /^leather chaps$/i,
-            regularPosition: 2,
+            regularPosition: 4,
+        },
+    },
+    {
+        aliases: /vamb/i,
+        product: {
+            name: 'leather vambraces',
+            optionPattern: /vamb/i,
+            inventoryPattern: /^leather (?:vambraces|vambs)$/i,
+            regularPosition: 3,
+        },
+    },
+    {
+        aliases: /coif/i,
+        product: {
+            name: 'leather coif',
+            optionPattern: /coif/i,
+            inventoryPattern: /^leather coif$/i,
+            regularPosition: 5,
+        },
+    },
+    {
+        aliases: /cowl/i,
+        product: {
+            name: 'leather cowl',
+            optionPattern: /cowl/i,
+            inventoryPattern: /^leather cowl$/i,
+            regularPosition: 6,
         },
     },
 ];
@@ -95,6 +121,39 @@ export function productPosition(product: CraftProduct, higherTierLogs: boolean):
     return higherTierLogs
         ? product.higherTierPosition ?? product.regularPosition
         : product.regularPosition;
+}
+
+function matches(pattern: RegExp, text: string): boolean {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+}
+
+export function matchingProductOptions(
+    options: readonly InterfaceOption[],
+    product: CraftProduct,
+): InterfaceOption[] {
+    return options.filter(option => matches(product.optionPattern, option.text));
+}
+
+/**
+ * Prefer exactly one item when an interface exposes Make-10/Make-5/Make-1
+ * components for the same product. A sole product option remains compatible
+ * with interfaces that do not expose a quantity in their text.
+ */
+export function resolveMakeOneOption(
+    options: readonly InterfaceOption[],
+    product: CraftProduct,
+): InterfaceOption | null {
+    const productOptions = matchingProductOptions(options, product);
+    const makeOne = productOptions.find(option =>
+        /\bmake\s*[-x]?\s*(?:1|one)\b/i.test(option.text)
+    );
+    if (makeOne) return makeOne;
+    const implicitSingle = productOptions.find(option =>
+        !/\bmake\s*[-x]?\s*(?:5|10)\b/i.test(option.text)
+    );
+    if (implicitSingle) return implicitSingle;
+    return productOptions.length === 1 ? productOptions[0]! : null;
 }
 
 export function findProducedItem(

--- a/sdk/crafting-products.ts
+++ b/sdk/crafting-products.ts
@@ -1,0 +1,111 @@
+import type { InventoryItem } from './types';
+import { countInventoryItem } from './action-reliability';
+
+export interface CraftProduct {
+    name: string;
+    optionPattern: RegExp;
+    inventoryPattern: RegExp;
+    regularPosition: number;
+    higherTierPosition?: number;
+}
+
+const FLETCH_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
+    {
+        aliases: /arrow|shaft/i,
+        product: {
+            name: 'arrow shafts',
+            optionPattern: /arrow|shaft/i,
+            inventoryPattern: /arrow shaft/i,
+            regularPosition: 0,
+        },
+    },
+    {
+        aliases: /short/i,
+        product: {
+            name: 'shortbow',
+            optionPattern: /short\s*bow/i,
+            inventoryPattern: /short\s*bow/i,
+            regularPosition: 1,
+            higherTierPosition: 0,
+        },
+    },
+    {
+        aliases: /long/i,
+        product: {
+            name: 'longbow',
+            optionPattern: /long\s*bow/i,
+            inventoryPattern: /long\s*bow/i,
+            regularPosition: 2,
+            higherTierPosition: 1,
+        },
+    },
+    {
+        aliases: /stock/i,
+        product: {
+            name: 'crossbow stock',
+            optionPattern: /stock/i,
+            inventoryPattern: /stock/i,
+            regularPosition: 3,
+            higherTierPosition: 3,
+        },
+    },
+];
+
+const LEATHER_PRODUCTS: Array<{ aliases: RegExp; product: CraftProduct }> = [
+    {
+        aliases: /body|armou?r/i,
+        product: {
+            name: 'leather body',
+            optionPattern: /body|armou?r/i,
+            inventoryPattern: /^leather body$/i,
+            regularPosition: 0,
+        },
+    },
+    {
+        aliases: /glove|vamb/i,
+        product: {
+            name: 'leather gloves',
+            optionPattern: /glove|vamb/i,
+            inventoryPattern: /^leather gloves$/i,
+            regularPosition: 1,
+        },
+    },
+    {
+        aliases: /chap|leg/i,
+        product: {
+            name: 'leather chaps',
+            optionPattern: /chap|leg/i,
+            inventoryPattern: /^leather chaps$/i,
+            regularPosition: 2,
+        },
+    },
+];
+
+export function resolveFletchProduct(product?: string): CraftProduct | null {
+    if (!product) return FLETCH_PRODUCTS[0]!.product;
+    return FLETCH_PRODUCTS.find(entry => entry.aliases.test(product))?.product ?? null;
+}
+
+export function resolveLeatherProduct(product?: string): CraftProduct | null {
+    if (!product) return LEATHER_PRODUCTS[1]!.product;
+    return LEATHER_PRODUCTS.find(entry => entry.aliases.test(product))?.product ?? null;
+}
+
+export function productPosition(product: CraftProduct, higherTierLogs: boolean): number {
+    return higherTierLogs
+        ? product.higherTierPosition ?? product.regularPosition
+        : product.regularPosition;
+}
+
+export function findProducedItem(
+    before: readonly InventoryItem[],
+    after: readonly InventoryItem[],
+    product: CraftProduct,
+): InventoryItem | null {
+    const oldCount = countInventoryItem(before, product.inventoryPattern);
+    if (countInventoryItem(after, product.inventoryPattern) <= oldCount) return null;
+    return after.find(item => {
+        product.inventoryPattern.lastIndex = 0;
+        return product.inventoryPattern.test(item.name);
+    }) ?? null;
+}

--- a/sdk/formatter.ts
+++ b/sdk/formatter.ts
@@ -104,6 +104,7 @@ export function formatWorldState(
             for (const opt of state.interface.options) {
                 lines.push(`  ${opt.index}. ${opt.text}`);
             }
+            lines.push('(Select with sdk.clickInterfaceOption("text") or an option object; shown numbers are 1-based labels.)');
         }
         if (!state.shop?.isOpen && !state.bank?.isOpen) {
             lines.push('(This modal blocks most actions - close it with bot.closeInterface() or sdk.sendCloseModal())');
@@ -151,24 +152,28 @@ export function formatWorldState(
     const maxSlots = 28;
     const emptySlots = maxSlots - usedSlots;
     lines.push(`## Inventory (${emptySlots} empty slots)`);
+    lines.push('(Quantities aggregated by name; slot usage shown per item.)');
     if ((state.inventory || []).length === 0) {
         lines.push('(Empty)');
     } else {
-        const itemCounts = new Map<string, { count: number; options: string[] }>();
+        const itemCounts = new Map<string, { count: number; slots: number; options: string[] }>();
         for (const item of state.inventory) {
             const existing = itemCounts.get(item.name);
             if (existing) {
                 existing.count += item.count;
+                existing.slots += 1;
             } else {
                 itemCounts.set(item.name, {
                     count: item.count,
+                    slots: 1,
                     options: item.optionsWithIndex?.map(o => o.text) ?? []
                 });
             }
         }
         for (const [name, data] of itemCounts) {
             const opts = data.options.length > 0 ? ` [${data.options.join(', ')}]` : '';
-            lines.push(`- ${name} x${data.count}${opts}`);
+            const slots = data.slots === 1 ? '1 slot' : `${data.slots} slots`;
+            lines.push(`- ${name} x${data.count} across ${slots}${opts}`);
         }
     }
 
@@ -177,7 +182,7 @@ export function formatWorldState(
         lines.push('');
         lines.push('## Equipment');
         for (const item of state.equipment) {
-            lines.push(`- ${item.name}`);
+            lines.push(`- ${item.name} x${item.count}`);
         }
     }
 

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -19,11 +19,52 @@ import type {
     BotStatus,
     PrayerState,
     PrayerName,
-    GameMessage
+    GameMessage,
+    InterfaceOption,
 } from './types';
 import { PRAYER_INDICES, PRAYER_NAMES, PLAYER_CHAT_TYPES, isPlayerChat } from './types';
 import { ChatHistory } from './chat-history';
 import * as pathfinding from './pathfinding';
+import { resolveInterfaceOption, type InterfaceOptionSelector } from './action-reliability';
+
+const SDK_CONFIG_KEYS = new Set<keyof SDKConfig>([
+    'botUsername', 'password', 'gatewayUrl', 'host', 'port', 'connectionMode',
+    'autoLaunchBrowser', 'freshDataThreshold', 'browserLaunchUrl',
+    'browserLaunchTimeout', 'readyTimeout', 'actionTimeout', 'autoReconnect',
+    'reconnectMaxRetries', 'reconnectBaseDelay', 'reconnectMaxDelay', 'showChat',
+]);
+
+function validateSDKConfig(config: SDKConfig): void {
+    if (!config || typeof config !== 'object') {
+        throw new TypeError('BotSDK config must be an object');
+    }
+    if (typeof config.botUsername !== 'string' || !config.botUsername.trim()) {
+        if ('botName' in config) {
+            throw new TypeError('BotSDK config requires "botUsername"; replace the unsupported "botName" key');
+        }
+        throw new TypeError('BotSDK config.botUsername must be a non-empty string');
+    }
+    const unknown = Object.keys(config).filter(key => !SDK_CONFIG_KEYS.has(key as keyof SDKConfig));
+    if (unknown.length > 0) {
+        console.warn(`[BotSDK] Unknown config option${unknown.length === 1 ? '' : 's'} ignored: ${unknown.join(', ')}`);
+    }
+}
+
+function editDistance(left: string, right: string): number {
+    const row = Array.from({ length: right.length + 1 }, (_, index) => index);
+    for (let i = 1; i <= left.length; i++) {
+        let diagonal = row[0]!;
+        row[0] = i;
+        for (let j = 1; j <= right.length; j++) {
+            const above = row[j]!;
+            row[j] = left[i - 1] === right[j - 1]
+                ? diagonal
+                : 1 + Math.min(diagonal, above, row[j - 1]!);
+            diagonal = above;
+        }
+    }
+    return row[right.length]!;
+}
 
 /**
  * Derive the gateway WebSocket URL from a SERVER env value.
@@ -119,6 +160,7 @@ export class BotSDK {
     private connectionListeners = new Set<(state: ConnectionState, attempt?: number) => void>();
     private connectPromise: Promise<void> | null = null;
     private sdkClientId: string;
+    private warnedSkillNames = new Set<string>();
 
     /** True once the gateway has accepted our credentials (sdk_connected received). */
     private authenticated = false;
@@ -130,8 +172,9 @@ export class BotSDK {
     private intentionalDisconnect = false;
 
     constructor(config: SDKConfig) {
+        validateSDKConfig(config);
         this.config = {
-            botUsername: config.botUsername,
+            botUsername: config.botUsername.trim(),
             password: config.password || '',
             gatewayUrl: config.gatewayUrl || '',
             host: config.host || 'localhost',
@@ -702,12 +745,26 @@ export class BotSDK {
         });
     }
 
-    /** Get a skill by name (case-insensitive). */
+    /** Get a skill by name (case-insensitive; HP aliases Hitpoints). */
     getSkill(name: string): SkillState | null {
         if (!this.state) return null;
-        return this.state.skills.find(s =>
-            s.name.toLowerCase() === name.toLowerCase()
-        ) || null;
+        const requested = name.trim().toLowerCase();
+        const normalized = /^(hp|hitpoint|hitpoints)$/.test(requested) ? 'hitpoints' : requested;
+        const skill = this.state.skills.find(s => s.name.toLowerCase() === normalized) || null;
+        if (!skill && normalized && !this.warnedSkillNames.has(normalized)) {
+            this.warnedSkillNames.add(normalized);
+            const closest = this.state.skills
+                .map(candidate => ({
+                    candidate,
+                    distance: editDistance(normalized, candidate.name.toLowerCase()),
+                }))
+                .sort((a, b) => a.distance - b.distance)[0];
+            const suggestion = closest && closest.distance <= Math.max(2, Math.floor(normalized.length / 3))
+                ? ` Did you mean "${closest.candidate.name}"?`
+                : '';
+            console.warn(`[BotSDK] Unknown skill "${name}".${suggestion}`);
+        }
+        return skill;
     }
 
     /** Get XP for a skill by name. */
@@ -1072,23 +1129,51 @@ export class BotSDK {
         return this.sendAction({ type: 'clickComponentWithOption', componentId, optionIndex, slot, reason: 'SDK' });
     }
 
-    /** Click an interface option by index. Convenience wrapper that looks up componentId from state. */
-    async sendClickInterfaceOption(optionIndex: number): Promise<ActionResult> {
+    /**
+     * Click an interface option by 0-based array position.
+     * Prefer clickInterfaceOption() when selecting from published state.
+     */
+    async sendClickInterfaceOption(arrayPosition: number): Promise<ActionResult> {
         const state = this.getState();
         if (!state?.interface?.isOpen) {
-            return { success: false, message: 'No interface open' };
+            return { success: false, message: 'No interface open', reason: 'no_interface' };
         }
 
         const options = state.interface.options;
-        if (optionIndex < 0 || optionIndex >= options.length) {
-            return { success: false, message: `Invalid option index ${optionIndex}, interface has ${options.length} options` };
+        if (arrayPosition < 0 || arrayPosition >= options.length) {
+            return {
+                success: false,
+                message: `Invalid array position ${arrayPosition}; interface has ${options.length} options`,
+                reason: 'no_match',
+            };
         }
 
-        const option = options[optionIndex];
+        const option = options[arrayPosition];
         if (!option) {
-            return { success: false, message: `Option ${optionIndex} not found` };
+            return { success: false, message: `Option at array position ${arrayPosition} not found`, reason: 'no_match' };
         }
 
+        return this.sendClickComponent(option.componentId);
+    }
+
+    /**
+     * Click exactly one interface option by its state object or visible text.
+     * This API never interprets InterfaceOption.index as an array position.
+     */
+    async clickInterfaceOption(selector: InterfaceOptionSelector): Promise<ActionResult> {
+        const state = this.getState();
+        if (!state?.interface?.isOpen) {
+            return { success: false, message: 'No interface open', reason: 'no_interface' };
+        }
+        const option: InterfaceOption | null = resolveInterfaceOption(state.interface.options, selector);
+        if (!option) {
+            const available = state.interface.options.map(candidate => `"${candidate.text}"`).join(', ') || '(none)';
+            return {
+                success: false,
+                message: `No interface option matched ${String(selector)}. Available: ${available}`,
+                reason: 'no_match',
+            };
+        }
         return this.sendClickComponent(option.componentId);
     }
 

--- a/sdk/test/porcelain-reliability.test.ts
+++ b/sdk/test/porcelain-reliability.test.ts
@@ -158,12 +158,23 @@ async function run(): Promise<void> {
             skills: [{ name: 'Fletching', level: 10, baseLevel: 10, experience: 100 }],
             inventory: [item(1, 'Knife', 0), item(2, 'Logs', 1)],
         });
+        const fletchOptions = [
+            { index: 1, text: 'Make-10 Arrow shafts', componentId: 110 },
+            { index: 2, text: 'Make-5 Arrow shafts', componentId: 105 },
+            { index: 3, text: 'Make-1 Arrow shafts', componentId: 101 },
+            { index: 4, text: 'Make-10 Shortbow', componentId: 210 },
+            { index: 5, text: 'Make-5 Shortbow', componentId: 205 },
+            { index: 6, text: 'Make-1 Shortbow', componentId: 201 },
+            { index: 7, text: 'Make-10 Longbow', componentId: 310 },
+            { index: 8, text: 'Make-5 Longbow', componentId: 305 },
+            { index: 9, text: 'Make-1 Longbow', componentId: 301 },
+        ];
         const sdk = mount(initial);
         const calls: number[] = [];
         sdk.sendUseItemOnItem = async () => {
             (sdk as any).state = world({
                 ...initial,
-                interface: { isOpen: true, interfaceId: 1000, options },
+                interface: { isOpen: true, interfaceId: 1000, options: fletchOptions },
             });
             return { success: true, message: 'opened' };
         };
@@ -184,7 +195,26 @@ async function run(): Promise<void> {
         const result = await new BotActions(sdk).fletchLogs('longbow');
         check(
             'fletchLogs selects and verifies the requested product',
-            result.success && result.product?.name === 'Longbow (u)' && calls[0] === 303,
+            result.success && result.product?.name === 'Longbow (u)' &&
+                result.xpGained === 10 && calls[0] === 301,
+            result,
+        );
+    }
+
+    {
+        const sdk = mount(world({
+            skills: [{ name: 'Fletching', level: 10, baseLevel: 10, experience: 100 }],
+            inventory: [item(1, 'Knife', 0), item(2, 'Logs', 1)],
+        }));
+        let dispatched = false;
+        sdk.sendUseItemOnItem = async () => {
+            dispatched = true;
+            return { success: true, message: 'unexpected' };
+        };
+        const result = await new BotActions(sdk).fletchLogs('crossbow stock');
+        check(
+            'unsupported crossbow stock fails cleanly before dispatch',
+            !result.success && result.reason === 'no_matching_option' && !dispatched,
             result,
         );
     }
@@ -198,6 +228,17 @@ async function run(): Promise<void> {
                 item(22, 'Leather', 2),
             ],
         });
+        const leatherOptions = [
+            { index: 1, text: 'Make @lre@Leather body', componentId: 111 },
+            { index: 2, text: 'Make 10 pairs of @lre@Leather gloves', componentId: 210 },
+            { index: 3, text: 'Make 5 pairs of @lre@Leather gloves', componentId: 205 },
+            { index: 4, text: 'Make pair of @lre@Leather gloves', componentId: 222 },
+            { index: 5, text: 'Make pair of @lre@Leather boots', componentId: 333 },
+            { index: 6, text: 'Make @lre@Leather vambraces', componentId: 444 },
+            { index: 7, text: 'Make @lre@Leather chaps', componentId: 555 },
+            { index: 8, text: 'Make @lre@Leather coif', componentId: 666 },
+            { index: 9, text: 'Make @lre@Leather cowl', componentId: 777 },
+        ];
         const sdk = mount(initial);
         const calls: number[] = [];
         sdk.sendUseItemOnItem = async () => {
@@ -206,11 +247,7 @@ async function run(): Promise<void> {
                 interface: {
                     isOpen: true,
                     interfaceId: 2311,
-                    options: [
-                        { index: 1, text: 'Leather body', componentId: 111 },
-                        { index: 2, text: 'Leather gloves', componentId: 222 },
-                        { index: 3, text: 'Leather chaps', componentId: 333 },
-                    ],
+                    options: leatherOptions,
                 },
             });
             return { success: true, message: 'opened' };
@@ -235,8 +272,9 @@ async function run(): Promise<void> {
         };
         const result = await new BotActions(sdk).craftLeather('gloves');
         check(
-            'craftLeather does not confuse option.index 2 with array position 2',
-            result.success && result.product?.name === 'Leather gloves' && calls[0] === 222,
+            'craftLeather treats exact color-coded real Make option as one item',
+            result.success && result.product?.name === 'Leather gloves' &&
+                result.itemsCrafted === 1 && calls[0] === 222,
             result,
         );
     }
@@ -386,6 +424,39 @@ async function run(): Promise<void> {
 
     {
         const product = shopItem(50);
+        const sdk = mount(world({
+            shop: { isOpen: true, title: 'General store', shopItems: [product], playerItems: [product] },
+        }));
+        let buyDispatches = 0;
+        let sellDispatches = 0;
+        sdk.sendShopBuy = async () => {
+            buyDispatches++;
+            return { success: true, message: 'unexpected' };
+        };
+        sdk.sendShopSell = async () => {
+            sellDispatches++;
+            return { success: true, message: 'unexpected' };
+        };
+        const invalidAmounts = [Infinity, Number.MAX_SAFE_INTEGER];
+        for (const invalid of invalidAmounts) {
+            const buy = await new BotActions(sdk).buyFromShop(product, invalid);
+            const sell = await new BotActions(sdk).sellToShop(product, invalid);
+            check(
+                `shop methods reject ${invalid} before dispatch`,
+                !buy.success && buy.reason === 'invalid_amount' &&
+                    !sell.success && sell.reason === 'invalid_amount',
+                { buy, sell },
+            );
+        }
+        check(
+            'invalid and huge quantities dispatch no shop packets',
+            buyDispatches === 0 && sellDispatches === 0,
+            { buyDispatches, sellDispatches },
+        );
+    }
+
+    {
+        const product = shopItem(50);
         const initial = world({
             shop: { isOpen: true, title: 'General store', shopItems: [product], playerItems: [] },
         });
@@ -472,6 +543,123 @@ async function run(): Promise<void> {
     }
 
     {
+        const product = shopItem(2_000);
+        const initial = world({
+            shop: { isOpen: true, title: 'General store', shopItems: [], playerItems: [product] },
+        });
+        const sdk = mount(initial);
+        let packets = 0;
+        sdk.sendShopSell = async (_slot, amount = 1) => {
+            packets++;
+            const current = sdk.getState()!;
+            const remaining = current.shop.playerItems[0]!.count - amount;
+            (sdk as any).state = world({
+                ...current,
+                shop: {
+                    ...current.shop,
+                    playerItems: remaining > 0 ? [{ ...product, count: remaining }] : [],
+                },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('bounded sell-all delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).sellToShop(product, 'all');
+        check(
+            'sellToShop all stops at packet budget with truthful partial fill',
+            !result.success && result.reason === 'partial_fill' &&
+                result.requestedAmount === 2_000 && result.amountSold === 1_000 &&
+                packets === 100,
+            { result, packets },
+        );
+    }
+
+    {
+        const template = shopItem(1);
+        const holdings = Array.from({ length: 12 }, (_, slot) => ({
+            ...template,
+            slot,
+            count: 1,
+        }));
+        const initial = world({
+            shop: { isOpen: true, title: 'General store', shopItems: [], playerItems: holdings },
+        });
+        const sdk = mount(initial);
+        const dispatchedSlots: number[] = [];
+        sdk.sendShopSell = async (slot, amount = 1) => {
+            const current = sdk.getState()!;
+            const anchor = current.shop.playerItems.find(item => item.slot === slot && item.id === template.id);
+            if (!anchor) return { success: false, message: `stale slot ${slot}` };
+            dispatchedSlots.push(slot);
+            const remove = new Set(
+                current.shop.playerItems
+                    .filter(item => item.id === template.id)
+                    .slice(0, amount)
+                    .map(item => item.slot),
+            );
+            (sdk as any).state = world({
+                ...current,
+                shop: {
+                    ...current.shop,
+                    playerItems: current.shop.playerItems.filter(item => !remove.has(item.slot)),
+                },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('numeric sell delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).sellToShop(holdings[0]!, 12);
+        check(
+            'numeric sell re-resolves a live slot after a non-stackable batch',
+            result.success && result.amountSold === 12 &&
+                dispatchedSlots.length === 3 &&
+                dispatchedSlots[0] === 0 && dispatchedSlots[1] === 10 && dispatchedSlots[2] === 11,
+            { result, dispatchedSlots },
+        );
+    }
+
+    {
+        const coal = item(2000, 'Coal', 0, 4);
+        const stored = bankItem(4);
+        const sdk = mount(world({
+            inventory: [coal],
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: { isOpen: true, items: [stored] },
+        }));
+        let deposits = 0;
+        let withdrawals = 0;
+        sdk.sendBankDeposit = async () => {
+            deposits++;
+            return { success: true, message: 'unexpected' };
+        };
+        sdk.sendBankWithdraw = async () => {
+            withdrawals++;
+            return { success: true, message: 'unexpected' };
+        };
+        for (const invalid of [0, 1.5, NaN, Infinity, Number.MAX_SAFE_INTEGER]) {
+            const deposit = await new BotActions(sdk).depositItem(coal, invalid);
+            const withdraw = await new BotActions(sdk).withdrawItem(stored, invalid);
+            check(
+                `bank methods reject invalid amount ${String(invalid)}`,
+                !deposit.success && deposit.reason === 'invalid_amount' &&
+                    !withdraw.success && withdraw.reason === 'invalid_amount',
+                { deposit, withdraw },
+            );
+        }
+        check(
+            'invalid bank quantities dispatch no packets',
+            deposits === 0 && withdrawals === 0,
+            { deposits, withdrawals },
+        );
+    }
+
+    {
         const coal = item(2000, 'Coal', 0, 4);
         const initial = world({
             inventory: [coal],
@@ -479,7 +667,9 @@ async function run(): Promise<void> {
             bank: { isOpen: true, items: [] },
         });
         const sdk = mount(initial);
-        sdk.sendBankDeposit = async () => {
+        const dispatchedAmounts: number[] = [];
+        sdk.sendBankDeposit = async (_slot, amount) => {
+            dispatchedAmounts.push(amount ?? 1);
             (sdk as any).state = world({ ...initial, inventory: [] });
             return { success: true, message: 'sent' };
         };
@@ -500,7 +690,8 @@ async function run(): Promise<void> {
         const allResult = await new BotActions(sdk).depositItem(coal, -1);
         check(
             'depositItem all uses starting inventory quantity as requested',
-            allResult.success && allResult.requestedAmount === 4 && allResult.amountDeposited === 4,
+            allResult.success && allResult.requestedAmount === 4 &&
+                allResult.amountDeposited === 4 && dispatchedAmounts[1] === -1,
             allResult,
         );
     }
@@ -512,7 +703,9 @@ async function run(): Promise<void> {
             bank: { isOpen: true, items: [coal] },
         });
         const sdk = mount(initial);
-        sdk.sendBankWithdraw = async () => {
+        const dispatchedAmounts: number[] = [];
+        sdk.sendBankWithdraw = async (_slot, amount) => {
+            dispatchedAmounts.push(amount ?? 1);
             (sdk as any).state = world({
                 ...initial,
                 inventory: [item(coal.id, coal.name, 0, 4)],
@@ -536,8 +729,105 @@ async function run(): Promise<void> {
         const allResult = await new BotActions(sdk).withdrawItem(coal, -1);
         check(
             'withdrawItem all uses bank quantity as requested',
-            allResult.success && allResult.requestedAmount === 4 && allResult.amountWithdrawn === 4,
+            allResult.success && allResult.requestedAmount === 4 &&
+                allResult.amountWithdrawn === 4 && dispatchedAmounts[1] === -1,
             allResult,
+        );
+    }
+
+    {
+        const staleCoal = item(2000, 'Coal', 0, 1);
+        const liveCoal = item(2000, 'Coal', 1, 1);
+        const initial = world({
+            inventory: [item(9999, 'Feather', 0), liveCoal],
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: { isOpen: true, items: [] },
+        });
+        const sdk = mount(initial);
+        let dispatchedSlot = -1;
+        sdk.sendBankDeposit = async slot => {
+            dispatchedSlot = slot;
+            (sdk as any).state = world({
+                ...initial,
+                inventory: [item(9999, 'Feather', 0)],
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('stale deposit delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).depositItem(staleCoal, 1);
+        check(
+            'depositItem re-resolves stale object identity instead of mutating its occupied slot',
+            result.success && dispatchedSlot === 1,
+            { result, dispatchedSlot },
+        );
+    }
+
+    {
+        const staleCoal = bankItem(4);
+        const liveCoal = { ...staleCoal, slot: 4 };
+        const initial = world({
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: {
+                isOpen: true,
+                items: [
+                    { slot: 3, id: 9999, name: 'Feather', count: 1 },
+                    liveCoal,
+                ],
+            },
+        });
+        const sdk = mount(initial);
+        let dispatchedSlot = -1;
+        sdk.sendBankWithdraw = async slot => {
+            dispatchedSlot = slot;
+            (sdk as any).state = world({
+                ...initial,
+                inventory: [item(liveCoal.id, liveCoal.name, 0, 1)],
+                bank: { ...initial.bank, items: [{ ...liveCoal, count: 3 }] },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('stale withdraw delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).withdrawItem(staleCoal, 1);
+        check(
+            'withdrawItem re-resolves stale bank identity by id',
+            result.success && dispatchedSlot === 4,
+            { result, dispatchedSlot },
+        );
+    }
+
+    {
+        const coal = { ...bankItem(10), slot: 4 };
+        const initial = world({
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: { isOpen: true, items: [coal] },
+        });
+        const sdk = mount(initial);
+        sdk.sendBankWithdraw = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                inventory: [item(2001, 'Coal (noted)', 0, 4)],
+                bank: { isOpen: true, items: [{ ...coal, count: 6 }] },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('noted bank decrease not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).withdrawItem(coal, 4);
+        check(
+            'withdrawItem observes bank decrease and locates noted output',
+            result.success && result.amountWithdrawn === 4 && result.item?.id === 2001,
+            result,
         );
     }
 
@@ -546,12 +836,19 @@ async function run(): Promise<void> {
     check(
         'fletching positional fallbacks account for log tier',
         productPosition(resolveFletchProduct('long')!, false) === 2 &&
-            productPosition(resolveFletchProduct('long')!, true) === 1,
+            productPosition(resolveFletchProduct('long')!, true) === 1 &&
+            resolveFletchProduct('crossbow stock') === null,
     );
     check(
         'leather default and fallback are explicit',
         resolveLeatherProduct()?.name === 'leather gloves' &&
-            productPosition(resolveLeatherProduct('body')!, false) === 0,
+            productPosition(resolveLeatherProduct('body')!, false) === 0 &&
+            productPosition(resolveLeatherProduct('boots')!, false) === 2 &&
+            productPosition(resolveLeatherProduct('vambraces')!, false) === 3 &&
+            productPosition(resolveLeatherProduct('chaps')!, false) === 4 &&
+            productPosition(resolveLeatherProduct('coif')!, false) === 5 &&
+            productPosition(resolveLeatherProduct('cowl')!, false) === 6 &&
+            resolveLeatherProduct('vambraces')?.name === 'leather vambraces',
     );
 
     let configDiagnostic = '';

--- a/sdk/test/porcelain-reliability.test.ts
+++ b/sdk/test/porcelain-reliability.test.ts
@@ -1,0 +1,621 @@
+#!/usr/bin/env bun
+
+import { BotActions } from '../actions';
+import {
+    captureInteractionBaseline,
+    classifyQuantity,
+    detectInteractionEvidence,
+    resolveInterfaceOption,
+} from '../action-reliability';
+import { productPosition, resolveFletchProduct, resolveLeatherProduct } from '../crafting-products';
+import { formatWorldState } from '../formatter';
+import { BotSDK } from '../index';
+import type {
+    ActionResult,
+    BankItem,
+    BotWorldState,
+    InventoryItem,
+    NearbyLoc,
+    NearbyNpc,
+    ShopItem,
+} from '../types';
+
+let failures = 0;
+
+function check(label: string, condition: boolean, detail?: unknown): void {
+    if (condition) {
+        console.log(`  ok  ${label}`);
+        return;
+    }
+    failures++;
+    console.log(`  FAIL  ${label}${detail === undefined ? '' : ` — ${JSON.stringify(detail)}`}`);
+}
+
+function item(id: number, name: string, slot: number, count = 1): InventoryItem {
+    return { id, name, slot, count, optionsWithIndex: [] };
+}
+
+function loc(name = 'Tree'): NearbyLoc {
+    return {
+        id: 100,
+        name,
+        x: 3200,
+        z: 3200,
+        distance: 1,
+        options: ['Chop down'],
+        optionsWithIndex: [{ text: 'Chop down', opIndex: 1 }],
+    };
+}
+
+function npc(name = 'Shop keeper'): NearbyNpc {
+    return {
+        index: 7,
+        name,
+        combatLevel: 0,
+        x: 3200,
+        z: 3200,
+        distance: 1,
+        hp: 0,
+        maxHp: 0,
+        healthPercent: null,
+        targetIndex: -1,
+        inCombat: false,
+        combatCycle: 0,
+        animId: -1,
+        spotanimId: -1,
+        options: ['Talk-to', 'Trade'],
+        optionsWithIndex: [
+            { text: 'Talk-to', opIndex: 1 },
+            { text: 'Trade', opIndex: 2 },
+        ],
+    };
+}
+
+function shopItem(count: number): ShopItem {
+    return {
+        slot: 0,
+        id: 1000,
+        name: 'Bucket',
+        count,
+        baseCost: 2,
+        buyPrice: 2,
+        sellPrice: 1,
+    };
+}
+
+function bankItem(count: number): BankItem {
+    return { slot: 3, id: 2000, name: 'Coal', count };
+}
+
+function world(overrides: Partial<BotWorldState> = {}): BotWorldState {
+    return {
+        tick: 1,
+        inGame: true,
+        player: {
+            x: 3200,
+            z: 3200,
+            worldX: 3200,
+            worldZ: 3200,
+            level: 0,
+            animId: -1,
+            name: 'test',
+            combatLevel: 3,
+            combat: { inCombat: false, targetIndex: -1 },
+        } as BotWorldState['player'],
+        skills: [],
+        inventory: [],
+        equipment: [],
+        nearbyNpcs: [],
+        nearbyPlayers: [],
+        nearbyLocs: [],
+        groundItems: [],
+        gameMessages: [],
+        recentDialogs: [],
+        dialog: { isOpen: false, isWaiting: false, options: [] },
+        interface: { isOpen: false, interfaceId: -1, options: [] },
+        shop: { isOpen: false, title: '', shopItems: [], playerItems: [] },
+        bank: { isOpen: false, items: [] },
+        modalOpen: false,
+        modalInterface: -1,
+        combatEvents: [],
+        prayers: undefined as unknown as BotWorldState['prayers'],
+        ...overrides,
+    };
+}
+
+function mount(state: BotWorldState): BotSDK {
+    const sdk = new BotSDK({ botUsername: 'test' });
+    (sdk as unknown as { state: BotWorldState }).state = state;
+    return sdk;
+}
+
+async function run(): Promise<void> {
+    console.log('Porcelain reliability:');
+
+    const options = [
+        { index: 1, text: 'Arrow shafts', componentId: 101 },
+        { index: 2, text: 'Shortbow', componentId: 202 },
+        { index: 3, text: 'Longbow', componentId: 303 },
+    ];
+    check(
+        'option resolver returns component identity, not ordinal-as-position',
+        resolveInterfaceOption(options, /long/i)?.componentId === 303,
+    );
+
+    {
+        const sdk = mount(world({ interface: { isOpen: true, interfaceId: 1, options } }));
+        const calls: number[] = [];
+        sdk.sendClickComponent = async componentId => {
+            calls.push(componentId);
+            return { success: true, message: 'clicked' };
+        };
+        const result = await sdk.clickInterfaceOption(options[2]!);
+        check('clickInterfaceOption dispatches the resolved component', result.success && calls[0] === 303, calls);
+    }
+
+    {
+        const initial = world({
+            skills: [{ name: 'Fletching', level: 10, baseLevel: 10, experience: 100 }],
+            inventory: [item(1, 'Knife', 0), item(2, 'Logs', 1)],
+        });
+        const sdk = mount(initial);
+        const calls: number[] = [];
+        sdk.sendUseItemOnItem = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                interface: { isOpen: true, interfaceId: 1000, options },
+            });
+            return { success: true, message: 'opened' };
+        };
+        sdk.sendClickComponent = async componentId => {
+            calls.push(componentId);
+            (sdk as any).state = world({
+                ...initial,
+                skills: [{ name: 'Fletching', level: 10, baseLevel: 10, experience: 110 }],
+                inventory: [item(1, 'Knife', 0), item(10, 'Longbow (u)', 1)],
+            });
+            return { success: true, message: 'clicked' };
+        };
+        sdk.waitForCondition = async (predicate: (state: BotWorldState) => boolean) => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('predicate not met');
+            return current;
+        };
+        const result = await new BotActions(sdk).fletchLogs('longbow');
+        check(
+            'fletchLogs selects and verifies the requested product',
+            result.success && result.product?.name === 'Longbow (u)' && calls[0] === 303,
+            result,
+        );
+    }
+
+    {
+        const initial = world({
+            skills: [{ name: 'Crafting', level: 10, baseLevel: 10, experience: 100 }],
+            inventory: [
+                item(20, 'Needle', 0),
+                item(21, 'Thread', 1),
+                item(22, 'Leather', 2),
+            ],
+        });
+        const sdk = mount(initial);
+        const calls: number[] = [];
+        sdk.sendUseItemOnItem = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                interface: {
+                    isOpen: true,
+                    interfaceId: 2311,
+                    options: [
+                        { index: 1, text: 'Leather body', componentId: 111 },
+                        { index: 2, text: 'Leather gloves', componentId: 222 },
+                        { index: 3, text: 'Leather chaps', componentId: 333 },
+                    ],
+                },
+            });
+            return { success: true, message: 'opened' };
+        };
+        sdk.sendClickComponent = async componentId => {
+            calls.push(componentId);
+            (sdk as any).state = world({
+                ...initial,
+                skills: [{ name: 'Crafting', level: 10, baseLevel: 10, experience: 114 }],
+                inventory: [
+                    item(20, 'Needle', 0),
+                    item(21, 'Thread', 1),
+                    item(23, 'Leather gloves', 2),
+                ],
+            });
+            return { success: true, message: 'clicked' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('predicate not met');
+            return current;
+        };
+        const result = await new BotActions(sdk).craftLeather('gloves');
+        check(
+            'craftLeather does not confuse option.index 2 with array position 2',
+            result.success && result.product?.name === 'Leather gloves' && calls[0] === 222,
+            result,
+        );
+    }
+
+    {
+        const tree = loc();
+        const sdk = mount(world({ nearbyLocs: [tree] }));
+        sdk.sendInteractLoc = async (): Promise<ActionResult> => ({ success: true, message: 'sent' });
+        sdk.waitForCondition = async (predicate: (state: BotWorldState) => boolean) => {
+            const depleted = world({ tick: 20, nearbyLocs: [] });
+            if (!predicate(depleted)) throw new Error('deadline');
+            return depleted;
+        };
+        const result = await new BotActions(sdk).chopTree(tree);
+        check(
+            'a depleted tree is not attributed to this bot without gained logs',
+            !result.success && result.reason === 'timeout',
+            result,
+        );
+    }
+
+    {
+        const oldMessage = {
+            type: 0,
+            text: 'old',
+            sender: '',
+            tick: 5,
+            fromSelf: false,
+            observationId: 1,
+        };
+        const initial = world({
+            tick: 5,
+            skills: [{ name: 'Firemaking', level: 1, baseLevel: 1, experience: 0 }],
+            inventory: [item(30, 'Tinderbox', 0), item(31, 'Logs', 1)],
+            gameMessages: [oldMessage],
+        });
+        const sdk = mount(initial);
+        sdk.sendUseItemOnItem = async () => ({ success: true, message: 'sent' });
+        sdk.waitForCondition = async predicate => {
+            const failed = world({
+                ...initial,
+                gameMessages: [
+                    oldMessage,
+                    {
+                        type: 0,
+                        text: "You can't light a fire here.",
+                        sender: '',
+                        tick: 5,
+                        fromSelf: false,
+                        observationId: 2,
+                    },
+                ],
+            });
+            if (!predicate(failed)) throw new Error('same-tick message not observed');
+            return failed;
+        };
+        const result = await new BotActions(sdk).burnLogs();
+        check(
+            'burnLogs sees same-tick failures through optional observationId',
+            !result.success && result.reason === 'bad_location',
+            result,
+        );
+    }
+
+    {
+        const initial = world({
+            skills: [{ name: 'Mining', level: 1, baseLevel: 1, experience: 0 }],
+        });
+        const baseline = captureInteractionBaseline(initial);
+        const idle = detectInteractionEvidence(world({ ...initial, tick: 100 }), baseline);
+        const xp = detectInteractionEvidence(world({
+            ...initial,
+            tick: 100,
+            skills: [{ name: 'Mining', level: 1, baseLevel: 1, experience: 5 }],
+        }), baseline);
+        check('idle ticks are not interaction evidence', idle === null, idle);
+        check('XP is interaction evidence', xp === 'xp', xp);
+    }
+
+    {
+        const rock = loc('Copper rock');
+        const initial = world({
+            nearbyLocs: [rock],
+            skills: [{ name: 'Mining', level: 1, baseLevel: 1, experience: 0 }],
+        });
+        const sdk = mount(initial);
+        let deadline = 0;
+        sdk.sendInteractLoc = async () => ({ success: true, message: 'sent' });
+        sdk.waitForCondition = async (predicate, timeout) => {
+            deadline = timeout ?? 0;
+            const idle = world({ ...initial, tick: 100 });
+            check('interactLoc does not complete on idle ticks', !predicate(idle));
+            const completed = world({
+                ...initial,
+                tick: 101,
+                skills: [{ name: 'Mining', level: 1, baseLevel: 1, experience: 5 }],
+            });
+            if (!predicate(completed)) throw new Error('XP evidence not accepted');
+            return completed;
+        };
+        const result = await new BotActions(sdk).interactLoc(rock, 1, { timeout: 4321 });
+        check(
+            'interactLoc waits for effect evidence with caller deadline',
+            result.success && result.evidence === 'xp' && deadline === 4321,
+            result,
+        );
+    }
+
+    {
+        const target = npc('Man');
+        const initial = world({ nearbyNpcs: [target] });
+        const sdk = mount(initial);
+        sdk.sendInteractNpc = async () => ({ success: true, message: 'sent' });
+        sdk.waitForCondition = async (predicate, timeout) => {
+            const idle = world({ ...initial, tick: 100 });
+            check('interactNpc does not complete on idle ticks', !predicate(idle));
+            const completed = world({ ...initial, tick: 101, inventory: [item(10, 'Coins', 0, 3)] });
+            if (!predicate(completed) || timeout !== 5000) throw new Error('inventory evidence not accepted');
+            return completed;
+        };
+        const result = await new BotActions(sdk).interactNpc(target, 1);
+        check('interactNpc uses default real deadline and inventory evidence', result.success && result.evidence === 'inventory', result);
+    }
+
+    {
+        const target = npc('Guide');
+        const initial = world({ nearbyNpcs: [target] });
+        const sdk = mount(initial);
+        sdk.sendTalkToNpc = async () => ({ success: true, message: 'sent' });
+        sdk.waitForCondition = async (predicate, timeout) => {
+            const idle = world({ ...initial, tick: 100 });
+            check('talkTo does not fail on idle ticks', !predicate(idle));
+            const completed = world({
+                ...initial,
+                tick: 101,
+                dialog: { isOpen: true, isWaiting: false, options: [] },
+            });
+            if (!predicate(completed) || timeout !== 6789) throw new Error('dialog evidence not accepted');
+            return completed;
+        };
+        const result = await new BotActions(sdk).talkTo(target, { timeout: 6789 });
+        check('talkTo waits for dialog until caller deadline', result.success && result.dialog?.isOpen === true, result);
+    }
+
+    console.log('');
+    console.log('Quantity action methods:');
+
+    {
+        const product = shopItem(50);
+        const initial = world({
+            shop: { isOpen: true, title: 'General store', shopItems: [product], playerItems: [] },
+        });
+        const sdk = mount(initial);
+        sdk.sendShopBuy = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                inventory: [item(product.id, product.name, 0, 4)],
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('buy delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).buyFromShop(product, 10);
+        check(
+            'buyFromShop reports requested/actual and rejects partial fill',
+            !result.success && result.partial === true &&
+                result.requestedAmount === 10 && result.amountBought === 4 &&
+                result.reason === 'partial_fill',
+            result,
+        );
+    }
+
+    {
+        const product = shopItem(4);
+        const initial = world({
+            shop: { isOpen: true, title: 'General store', shopItems: [], playerItems: [product] },
+        });
+        const sdk = mount(initial);
+        sdk.sendShopSell = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                shop: { ...initial.shop, playerItems: [] },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('sell delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).sellToShop(product, 10);
+        check(
+            'sellToShop reports requested/actual and rejects partial fill',
+            !result.success && result.partial === true &&
+                result.requestedAmount === 10 && result.amountSold === 4 &&
+                result.reason === 'partial_fill',
+            result,
+        );
+    }
+
+    {
+        const product = shopItem(12);
+        const initial = world({
+            shop: { isOpen: true, title: 'General store', shopItems: [], playerItems: [product] },
+        });
+        const sdk = mount(initial);
+        sdk.sendShopSell = async (_slot, amount) => {
+            const current = sdk.getState()!;
+            const remaining = Math.max(0, current.shop.playerItems[0]!.count - (amount ?? 1));
+            (sdk as any).state = world({
+                ...current,
+                shop: {
+                    ...current.shop,
+                    playerItems: remaining > 0 ? [{ ...product, count: remaining }] : [],
+                },
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('sell-all delta not observed');
+            return current;
+        };
+        const result = await new BotActions(sdk).sellToShop(product, 'all');
+        check(
+            'sellToShop all defines requested amount from starting holdings',
+            result.success && result.requestedAmount === 12 && result.amountSold === 12,
+            result,
+        );
+    }
+
+    {
+        const coal = item(2000, 'Coal', 0, 4);
+        const initial = world({
+            inventory: [coal],
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: { isOpen: true, items: [] },
+        });
+        const sdk = mount(initial);
+        sdk.sendBankDeposit = async () => {
+            (sdk as any).state = world({ ...initial, inventory: [] });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('deposit delta not observed');
+            return current;
+        };
+        const partialResult = await new BotActions(sdk).depositItem(coal, 10);
+        check(
+            'depositItem rejects partial fill and reports requested/actual',
+            !partialResult.success && partialResult.requestedAmount === 10 &&
+                partialResult.amountDeposited === 4 && partialResult.reason === 'partial_fill',
+            partialResult,
+        );
+
+        (sdk as any).state = initial;
+        const allResult = await new BotActions(sdk).depositItem(coal, -1);
+        check(
+            'depositItem all uses starting inventory quantity as requested',
+            allResult.success && allResult.requestedAmount === 4 && allResult.amountDeposited === 4,
+            allResult,
+        );
+    }
+
+    {
+        const coal = bankItem(4);
+        const initial = world({
+            interface: { isOpen: true, interfaceId: 12, options: [] },
+            bank: { isOpen: true, items: [coal] },
+        });
+        const sdk = mount(initial);
+        sdk.sendBankWithdraw = async () => {
+            (sdk as any).state = world({
+                ...initial,
+                inventory: [item(coal.id, coal.name, 0, 4)],
+            });
+            return { success: true, message: 'sent' };
+        };
+        sdk.waitForCondition = async predicate => {
+            const current = sdk.getState()!;
+            if (!predicate(current)) throw new Error('withdraw delta not observed');
+            return current;
+        };
+        const partialResult = await new BotActions(sdk).withdrawItem(coal, 10);
+        check(
+            'withdrawItem rejects partial fill and reports requested/actual',
+            !partialResult.success && partialResult.requestedAmount === 10 &&
+                partialResult.amountWithdrawn === 4 && partialResult.reason === 'partial_fill',
+            partialResult,
+        );
+
+        (sdk as any).state = initial;
+        const allResult = await new BotActions(sdk).withdrawItem(coal, -1);
+        check(
+            'withdrawItem all uses bank quantity as requested',
+            allResult.success && allResult.requestedAmount === 4 && allResult.amountWithdrawn === 4,
+            allResult,
+        );
+    }
+
+    const partial = classifyQuantity(10, 4);
+    check('partial quantities are explicitly incomplete', !partial.complete && partial.partial, partial);
+    check(
+        'fletching positional fallbacks account for log tier',
+        productPosition(resolveFletchProduct('long')!, false) === 2 &&
+            productPosition(resolveFletchProduct('long')!, true) === 1,
+    );
+    check(
+        'leather default and fallback are explicit',
+        resolveLeatherProduct()?.name === 'leather gloves' &&
+            productPosition(resolveLeatherProduct('body')!, false) === 0,
+    );
+
+    let configDiagnostic = '';
+    try {
+        new BotSDK({ botName: 'oops' } as any);
+    } catch (error) {
+        configDiagnostic = String(error);
+    }
+    check(
+        'botName config mistake explicitly suggests botUsername',
+        /botUsername.*botName/.test(configDiagnostic),
+        configDiagnostic,
+    );
+
+    {
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = message => warnings.push(String(message));
+        try {
+            new BotSDK({ botUsername: 'test', surpriseOption: true } as any);
+            check(
+                'unknown config keys warn without breaking compatibility',
+                warnings.some(message => /Unknown config option.*surpriseOption/.test(message)),
+                warnings,
+            );
+            const sdk = mount(world({
+                skills: [{ name: 'Hitpoints', level: 10, baseLevel: 10, experience: 1154 }],
+            }));
+            check('HP aliases Hitpoints', sdk.getSkill('HP')?.name === 'Hitpoints');
+            check(
+                'skill typo includes nearest-name diagnostic',
+                sdk.getSkill('Hitponts') === null && warnings.some(message => /Did you mean "Hitpoints"/.test(message)),
+                warnings,
+            );
+        } finally {
+            console.warn = originalWarn;
+        }
+    }
+
+    const formatted = formatWorldState(world({
+        inventory: [
+            item(1, 'Logs', 0),
+            item(1, 'Logs', 1),
+            item(2, 'Coins', 2, 500),
+        ],
+        equipment: [item(3, 'Bronze arrow', 0, 40)],
+    }));
+    check(
+        'formatter distinguishes aggregate quantities, slots, and equipment counts',
+        formatted.includes('Quantities aggregated by name') &&
+            formatted.includes('Logs x2 across 2 slots') &&
+            formatted.includes('Coins x500 across 1 slot') &&
+            formatted.includes('Bronze arrow x40'),
+    );
+
+    console.log('');
+    if (failures > 0) {
+        console.log(`FAILED — ${failures} case(s)`);
+        process.exit(1);
+    }
+    console.log('PASSED — all porcelain reliability cases');
+}
+
+run().catch(error => {
+    console.error(error);
+    process.exit(1);
+});

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -166,7 +166,16 @@ export interface DialogState {
 export interface InterfaceState {
     isOpen: boolean;
     interfaceId: number;
-    options: Array<{ index: number; text: string; componentId: number }>;
+    options: InterfaceOption[];
+}
+
+/** A clickable viewport-interface option as published in world state. */
+export interface InterfaceOption {
+    /** Human-facing 1-based ordinal. Do not use this as an array position. */
+    index: number;
+    text: string;
+    /** Stable component dispatched when this option is selected. */
+    componentId: number;
 }
 
 export interface ShopItem {
@@ -347,13 +356,22 @@ export type BotAction =
     | { type: 'scanGroundItems'; radius?: number; reason: string }
     | { type: 'togglePrayer'; prayerIndex: number; reason: string };
 
-export interface ActionResult {
+export type ActionPhase = 'validation' | 'routing' | 'dispatch' | 'observation' | 'completion';
+
+/**
+ * Compatibility-safe common contract for action outcomes.
+ * `phase` and `reason` remain optional while specialized results migrate.
+ */
+export interface ActionResultBase<Reason extends string = string> {
     success: boolean;
     message: string;
+    phase?: ActionPhase;
+    reason?: Reason;
+}
+
+export interface ActionResult extends ActionResultBase {
     /** Optional data payload (used by scan actions to return results) */
     data?: any;
-    /** Machine-readable failure category (e.g. 'cant_reach', 'no_match', 'timeout') */
-    reason?: string;
 }
 
 /**
@@ -450,16 +468,17 @@ export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'rec
 
 // ============ Result Types ============
 
-export interface ChopTreeResult {
-    success: boolean;
+export interface ChopTreeResult extends ActionResultBase<
+    'tree_not_found' | 'inventory_full' | 'cant_reach' | 'level_interrupted' | 'dispatch_failed' | 'timeout'
+> {
     logs?: InventoryItem;
-    message: string;
 }
 
-export interface BurnLogsResult {
-    success: boolean;
+export interface BurnLogsResult extends ActionResultBase<
+    'no_tinderbox' | 'no_logs' | 'cant_reach' | 'bad_location' | 'level_interrupted' | 'dispatch_failed' | 'timeout'
+> {
     xpGained: number;
-    message: string;
+    logsConsumed?: number;
 }
 
 export interface PickupResult {
@@ -469,22 +488,27 @@ export interface PickupResult {
     reason?: 'item_not_found' | 'cant_reach' | 'inventory_full' | 'timeout';
 }
 
-export interface TalkResult {
-    success: boolean;
+export interface TalkResult extends ActionResultBase<
+    'npc_not_found' | 'cant_reach' | 'dispatch_failed' | 'timeout'
+> {
     dialog?: DialogState;
-    message: string;
 }
 
-export interface ShopResult {
-    success: boolean;
+export interface ShopResult extends ActionResultBase<
+    'shop_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+> {
     item?: InventoryItem;
-    message: string;
+    requestedAmount?: number;
+    amountBought?: number;
+    partial?: boolean;
 }
 
-export interface ShopSellResult {
-    success: boolean;
-    message: string;
+export interface ShopSellResult extends ActionResultBase<
+    'shop_not_open' | 'item_not_found' | 'rejected' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+> {
+    requestedAmount?: number;
     amountSold?: number;
+    partial?: boolean;
     rejected?: boolean;
 }
 
@@ -528,19 +552,22 @@ export interface OpenDoorResult {
     door?: NearbyLoc;
 }
 
-export interface FletchResult {
-    success: boolean;
-    message: string;
+export interface FletchResult extends ActionResultBase<
+    'no_knife' | 'no_logs' | 'interface_not_opened' | 'no_matching_option' |
+    'level_too_low' | 'wrong_product' | 'dispatch_failed' | 'timeout'
+> {
     xpGained?: number;
     product?: InventoryItem;
 }
 
-export interface CraftLeatherResult {
-    success: boolean;
-    message: string;
+export interface CraftLeatherResult extends ActionResultBase<
+    'no_needle' | 'no_leather' | 'no_thread' | 'interface_not_opened' |
+    'no_matching_option' | 'level_too_low' | 'wrong_product' | 'dispatch_failed' |
+    'timeout' | 'no_xp_gained'
+> {
     xpGained?: number;
     itemsCrafted?: number;
-    reason?: 'no_needle' | 'no_leather' | 'no_thread' | 'interface_not_opened' | 'level_too_low' | 'timeout' | 'no_xp_gained';
+    product?: InventoryItem;
 }
 
 export interface SmithResult {
@@ -558,18 +585,21 @@ export interface OpenBankResult {
     reason?: 'no_bank_found' | 'no_bank_option' | 'timeout' | 'dialog_stuck' | 'cant_reach';
 }
 
-export interface BankDepositResult {
-    success: boolean;
-    message: string;
+export interface BankDepositResult extends ActionResultBase<
+    'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+> {
+    requestedAmount?: number;
     amountDeposited?: number;
-    reason?: 'bank_not_open' | 'item_not_found' | 'timeout';
+    partial?: boolean;
 }
 
-export interface BankWithdrawResult {
-    success: boolean;
-    message: string;
+export interface BankWithdrawResult extends ActionResultBase<
+    'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+> {
     item?: InventoryItem;
-    reason?: 'bank_not_open' | 'item_not_found' | 'timeout';
+    requestedAmount?: number;
+    amountWithdrawn?: number;
+    partial?: boolean;
 }
 
 export interface UseItemOnLocResult {
@@ -584,16 +614,28 @@ export interface UseItemOnNpcResult {
     reason?: 'item_not_found' | 'npc_not_found' | 'cant_reach' | 'timeout';
 }
 
-export interface InteractLocResult {
-    success: boolean;
-    message: string;
-    reason?: 'loc_not_found' | 'no_matching_option' | 'cant_reach' | 'timeout';
+export type InteractionEvidence =
+    'dialog' | 'interface' | 'animation' | 'inventory' | 'xp' | 'message' | 'custom';
+
+export interface InteractionWaitOptions {
+    /** Real deadline in milliseconds. Default: 5000. */
+    timeout?: number;
+    /** Additional task-specific evidence predicate. */
+    evidence?: (state: BotWorldState, initialState: BotWorldState) => boolean;
+    /** Treat a new game message matching this pattern as success evidence. */
+    message?: string | RegExp;
 }
 
-export interface InteractNpcResult {
-    success: boolean;
-    message: string;
-    reason?: 'npc_not_found' | 'no_matching_option' | 'cant_reach' | 'timeout';
+export interface InteractLocResult extends ActionResultBase<
+    'loc_not_found' | 'no_matching_option' | 'cant_reach' | 'dispatch_failed' | 'timeout'
+> {
+    evidence?: InteractionEvidence;
+}
+
+export interface InteractNpcResult extends ActionResultBase<
+    'npc_not_found' | 'no_matching_option' | 'cant_reach' | 'dispatch_failed' | 'timeout'
+> {
+    evidence?: InteractionEvidence;
 }
 
 export interface PickpocketResult {

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -495,7 +495,7 @@ export interface TalkResult extends ActionResultBase<
 }
 
 export interface ShopResult extends ActionResultBase<
-    'shop_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+    'invalid_amount' | 'shop_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
 > {
     item?: InventoryItem;
     requestedAmount?: number;
@@ -504,7 +504,7 @@ export interface ShopResult extends ActionResultBase<
 }
 
 export interface ShopSellResult extends ActionResultBase<
-    'shop_not_open' | 'item_not_found' | 'rejected' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+    'invalid_amount' | 'shop_not_open' | 'item_not_found' | 'rejected' | 'dispatch_failed' | 'partial_fill' | 'timeout'
 > {
     requestedAmount?: number;
     amountSold?: number;
@@ -512,7 +512,7 @@ export interface ShopSellResult extends ActionResultBase<
     rejected?: boolean;
 }
 
-export type SellAmount = 1 | 5 | 10 | 'all';
+export type SellAmount = number | 'all';
 
 export interface EquipResult {
     success: boolean;
@@ -586,7 +586,7 @@ export interface OpenBankResult {
 }
 
 export interface BankDepositResult extends ActionResultBase<
-    'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+    'invalid_amount' | 'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
 > {
     requestedAmount?: number;
     amountDeposited?: number;
@@ -594,7 +594,7 @@ export interface BankDepositResult extends ActionResultBase<
 }
 
 export interface BankWithdrawResult extends ActionResultBase<
-    'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
+    'invalid_amount' | 'bank_not_open' | 'item_not_found' | 'dispatch_failed' | 'partial_fill' | 'timeout'
 > {
     item?: InventoryItem;
     requestedAmount?: number;


### PR DESCRIPTION
## Summary
- select interface components by identity and verify the requested fletching/leather product, using the real Make-10/5/single layouts
- require attributable effects for chop/burn/talk/generic interactions instead of idle ticks or unrelated world changes
- report exact requested/actual quantities for shop and bank operations; partial fills are unsuccessful and machine-readable
- validate quantities before serialization, bound shop packet work/deadlines, and refresh item identity before every mutation
- support noted withdrawals by observing bank-stack decrease and expose current output items when identifiable
- add HP aliases/skill typo diagnostics, runtime SDK config validation, clearer inventory/equipment quantities, and a shared action phase/reason contract

## Adversarial review fixes
A separate review pass found and this branch fixes: non-finite/huge quantity hangs, stale non-stackable sell slots, accidental Make-10 leather selection, noted-withdraw timeouts, stale bank/inventory object selectors, and incomplete/misrouted leather products.

## Validation
- 44 focused porcelain reliability cases pass
- chat-history suite passes
- click-dialog suite passes (9 cases)
- webclient typecheck passes
- root typecheck reaches only the two pre-existing banking fixture nullability errors fixed by #43
- `git diff --check` passes

## Merge guidance
This is intentionally independent of #45 so both reviews could run simultaneously. It conflicts with #45 only in `sdk/actions.ts`, `sdk/index.ts`, and `sdk/types.ts`.

When reconciling, preserve #45's observation IDs/revision fields, death/HP state, target-specific attack evidence, action-timeout propagation, expiring door state, and browser FIFO behavior. Keep this PR's `ActionResultBase`, quantity/result types, selector/config/skill additions, and porcelain action bodies. For message checks, object baselines use `isMessageAfterBaseline`; numeric baselines use #45's `helpers.isMessageAfter`. Merge/regenerate #43 after both action PRs.
