### PR TITLE
Serialize execute_code sessions per bot

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -42,6 +42,13 @@ execute_code({
 })
 ```
 
+Calls for the same bot run in FIFO order, so two agent programs cannot
+interleave multi-step actions. If a call times out or is cancelled, the next
+call waits for any SDK operation that already started to settle. Calls for
+different bots may still run concurrently.
+
+`execute_code` runs trusted repository code; it is not a security sandbox.
+
 ### `list_bots`
 List all connected bots and their status.
 
@@ -108,6 +115,7 @@ bun run mcp/server.ts
 ```
 mcp/
 ├── server.ts           # MCP server (stdio transport)
+├── execution.ts        # Per-bot execution isolation
 └── api/
     └── index.ts        # BotManager - manages multiple connections
 ```

--- a/mcp/execution.test.ts
+++ b/mcp/execution.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from 'bun:test';
+import type { BotActions } from '../sdk/actions';
+import type { BotSDK } from '../sdk';
+import { executeCode, PerBotQueue } from './execution';
+
+function targets(
+  sdk: Record<string, unknown> = {},
+  bot: Record<string, unknown> = {},
+) {
+  return {
+    sdk: sdk as unknown as BotSDK,
+    bot: bot as unknown as BotActions,
+  };
+}
+
+describe('minimal execute_code session', () => {
+  test('executes TypeScript and captures request-scoped logs', async () => {
+    const outcome = await executeCode({
+      ...targets(),
+      code: `
+        const count: number = 2;
+        console.log("count", count);
+        return count + 1;
+      `,
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome).toMatchObject({
+      status: 'success',
+      result: 3,
+      logs: ['count 2'],
+    });
+  });
+
+  test('preserves logs when user code fails', async () => {
+    const outcome = await executeCode({
+      ...targets(),
+      code: 'console.warn("before"); throw new Error("boom");',
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome.status).toBe('error');
+    expect(outcome.error).toBe('boom');
+    expect(outcome.logs).toEqual(['[warn] before']);
+  });
+
+  test('drains unawaited SDK calls before reporting success', async () => {
+    let settled = false;
+    const outcome = await executeCode({
+      ...targets({
+        slow: async () => {
+          await Bun.sleep(20);
+          settled = true;
+        },
+      }),
+      code: '(sdk as any).slow(); return "done";',
+      timeoutMs: 1_000,
+    });
+
+    expect(outcome.status).toBe('success');
+    expect(outcome.result).toBe('done');
+    expect(settled).toBe(true);
+  });
+
+  test('blocks follow-up SDK calls after timeout and exposes quiescence', async () => {
+    const events: string[] = [];
+    let releaseSlow!: () => void;
+    const slow = new Promise<void>(resolve => { releaseSlow = resolve; });
+
+    const outcome = await executeCode({
+      ...targets({
+        first: async () => {
+          events.push('first:start');
+          await slow;
+          events.push('first:end');
+        },
+        second: async () => {
+          events.push('second');
+        },
+      }),
+      code: 'await (sdk as any).first(); await (sdk as any).second();',
+      timeoutMs: 10,
+    });
+
+    expect(outcome.status).toBe('timeout');
+    expect(events).toEqual(['first:start']);
+    expect(outcome.quiescence).toBeDefined();
+
+    releaseSlow();
+    await outcome.quiescence;
+    await Bun.sleep(0);
+    expect(events).toEqual(['first:start', 'first:end']);
+  });
+
+  test('classifies client cancellation separately from timeout', async () => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort('client stopped'), 5);
+
+    const outcome = await executeCode({
+      ...targets(),
+      code: 'await new Promise(() => {});',
+      timeoutMs: 1_000,
+      signal: controller.signal,
+    });
+
+    expect(outcome.status).toBe('cancelled');
+    expect(outcome.error).toBe('client stopped');
+  });
+});
+
+describe('per-bot FIFO', () => {
+  test('serializes one bot while allowing different bots concurrently', async () => {
+    const queue = new PerBotQueue();
+    const events: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>(resolve => { releaseFirst = resolve; });
+
+    const first = queue.run('alpha', async () => {
+      events.push('alpha:first');
+      await firstGate;
+      return { value: 1 };
+    });
+    const second = queue.run('alpha', async () => {
+      events.push('alpha:second');
+      return { value: 2 };
+    });
+    const other = queue.run('beta', async () => {
+      events.push('beta');
+      return { value: 3 };
+    });
+
+    expect(await other).toBe(3);
+    expect(events).toEqual(['alpha:first', 'beta']);
+    releaseFirst();
+    expect(await Promise.all([first, second])).toEqual([1, 2]);
+    expect(events).toEqual(['alpha:first', 'beta', 'alpha:second']);
+  });
+
+  test('keeps the next session queued until a timed-out call is quiescent', async () => {
+    const queue = new PerBotQueue();
+    const events: string[] = [];
+    let releaseCall!: () => void;
+    const inFlight = new Promise<void>(resolve => { releaseCall = resolve; });
+
+    const first = await queue.run('alpha', async () => ({
+      value: 'timeout response',
+      holdUntil: inFlight,
+    }));
+    expect(first).toBe('timeout response');
+
+    const second = queue.run('alpha', async () => {
+      events.push('second');
+      return { value: 'done' };
+    });
+    await Bun.sleep(5);
+    expect(events).toEqual([]);
+
+    releaseCall();
+    expect(await second).toBe('done');
+    expect(events).toEqual(['second']);
+  });
+});

--- a/mcp/execution.ts
+++ b/mcp/execution.ts
@@ -1,0 +1,267 @@
+import type { BotActions } from '../sdk/actions';
+import type { BotSDK } from '../sdk';
+
+const MAX_LOG_ENTRIES = 100;
+const MAX_LOG_CHARS = 20_000;
+
+export interface ExecutionOutcome {
+  status: 'success' | 'error' | 'timeout' | 'cancelled';
+  result?: unknown;
+  error?: string;
+  logs: string[];
+  /** Resolves when SDK calls that started before cancellation have settled. */
+  quiescence?: Promise<void>;
+}
+
+export interface ExecuteCodeOptions {
+  bot: BotActions;
+  sdk: BotSDK;
+  code: string;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Execute one agent program and stop it from starting SDK calls after timeout
+ * or cancellation. Already-started calls cannot be aborted by the public SDK,
+ * so their settlement is exposed as `quiescence`.
+ */
+export async function executeCode(options: ExecuteCodeOptions): Promise<ExecutionOutcome> {
+  const logs: string[] = [];
+  let logChars = 0;
+  let omittedLogs = 0;
+  const inFlight = new Set<Promise<unknown>>();
+  let acceptingCalls = true;
+
+  const appendLog = (level: string, values: unknown[]) => {
+    const prefix = level === 'log' ? '' : `[${level}] `;
+    const rendered = prefix + values.map(formatValue).join(' ');
+    const remaining = MAX_LOG_CHARS - logChars;
+    if (logs.length >= MAX_LOG_ENTRIES || remaining <= 0) {
+      omittedLogs++;
+      return;
+    }
+    const entry = rendered.length <= remaining
+      ? rendered
+      : `${rendered.slice(0, Math.max(0, remaining - 1))}…`;
+    logs.push(entry);
+    logChars += entry.length;
+    if (entry.length < rendered.length) omittedLogs++;
+  };
+
+  const scopedConsole = {
+    log: (...values: unknown[]) => appendLog('log', values),
+    info: (...values: unknown[]) => appendLog('info', values),
+    debug: (...values: unknown[]) => appendLog('debug', values),
+    warn: (...values: unknown[]) => appendLog('warn', values),
+    error: (...values: unknown[]) => appendLog('error', values),
+  };
+
+  const guarded = <T extends object>(target: T): T => new Proxy(target, {
+    get(object, property, receiver) {
+      const value = Reflect.get(object, property, receiver);
+      if (typeof value !== 'function') return value;
+      return (...args: unknown[]) => {
+        if (!acceptingCalls) {
+          throw new Error(`Execution ended; refusing ${String(property)}()`);
+        }
+        const result = Reflect.apply(value, object, args);
+        if (!isPromiseLike(result)) return result;
+        const tracked = Promise.resolve(result);
+        inFlight.add(tracked);
+        tracked.finally(() => inFlight.delete(tracked)).catch(() => {});
+        return tracked;
+      };
+    },
+  });
+
+  const finishLogs = () => {
+    if (omittedLogs > 0) logs.push(`[logs truncated: ${omittedLogs} omitted]`);
+    return logs;
+  };
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener = () => {};
+  try {
+    if (options.signal?.aborted) {
+      return {
+        status: 'cancelled',
+        error: abortMessage(options.signal),
+        logs: finishLogs(),
+      };
+    }
+
+    const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+    const fn = new AsyncFunction(
+      'bot',
+      'sdk',
+      'console',
+      transpileBody(options.code),
+    );
+    const invocation = (async () => {
+      const result = await fn(
+        guarded(options.bot),
+        guarded(options.sdk),
+        scopedConsole,
+      );
+      acceptingCalls = false;
+      while (inFlight.size > 0) {
+        await Promise.allSettled([...inFlight]);
+      }
+      return result;
+    })();
+    invocation.catch(() => {});
+
+    const terminal = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new TerminalError(
+          'timeout',
+          `Code execution timed out after ${formatDuration(options.timeoutMs)}`,
+        )),
+        options.timeoutMs,
+      );
+      if (options.signal) {
+        const onAbort = () => reject(new TerminalError(
+          'cancelled',
+          abortMessage(options.signal!),
+        ));
+        options.signal.addEventListener('abort', onAbort, { once: true });
+        removeAbortListener = () => options.signal?.removeEventListener('abort', onAbort);
+      }
+    });
+
+    return {
+      status: 'success',
+      result: await Promise.race([invocation, terminal]),
+      logs: finishLogs(),
+    };
+  } catch (error) {
+    acceptingCalls = false;
+    const pending = [...inFlight];
+    return {
+      status: error instanceof TerminalError ? error.status : 'error',
+      error: error instanceof Error ? error.message : String(error),
+      logs: finishLogs(),
+      quiescence: pending.length > 0
+        ? Promise.allSettled(pending).then(() => {})
+        : undefined,
+    };
+  } finally {
+    acceptingCalls = false;
+    if (timeoutId) clearTimeout(timeoutId);
+    removeAbortListener();
+  }
+}
+
+export interface QueueResult<T> {
+  value: T;
+  /** Keep the per-bot lock after returning `value` until this settles. */
+  holdUntil?: Promise<unknown>;
+}
+
+/** Minimal per-bot FIFO. Different bots may still execute concurrently. */
+export class PerBotQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async run<T>(
+    botName: string,
+    task: () => Promise<QueueResult<T>>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const previous = this.tails.get(botName) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    const tail = previous.catch(() => {}).then(() => gate);
+    this.tails.set(botName, tail);
+    tail.finally(() => {
+      if (this.tails.get(botName) === tail) this.tails.delete(botName);
+    }).catch(() => {});
+
+    try {
+      await waitForTurn(previous, signal);
+    } catch (error) {
+      release();
+      throw error;
+    }
+
+    if (signal?.aborted) {
+      release();
+      throw new Error('Cancelled while waiting for the bot execution lock');
+    }
+
+    try {
+      const result = await task();
+      if (result.holdUntil) {
+        result.holdUntil.finally(release).catch(() => {});
+      } else {
+        release();
+      }
+      return result.value;
+    } catch (error) {
+      release();
+      throw error;
+    }
+  }
+}
+
+function transpileBody(code: string): string {
+  const source = `async function __execute(bot: any, sdk: any, console: any) {
+${code}
+}`;
+  try {
+    const javascript = new Bun.Transpiler({ loader: 'ts', target: 'bun' }).transformSync(source);
+    return `${javascript}\nreturn await __execute(bot, sdk, console);`;
+  } catch (error) {
+    throw new Error(`TypeScript compilation failed: ${error instanceof Error ? error.message : error}`);
+  }
+}
+
+function waitForTurn(previous: Promise<void>, signal?: AbortSignal): Promise<void> {
+  if (!signal) return previous;
+  if (signal.aborted) {
+    return Promise.reject(new Error('Cancelled while waiting for the bot execution lock'));
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(new Error('Cancelled while waiting for the bot execution lock'));
+    signal.addEventListener('abort', onAbort, { once: true });
+    previous.then(resolve, resolve).finally(() => {
+      signal.removeEventListener('abort', onAbort);
+    });
+  });
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === 'object' || typeof value === 'function') &&
+    value !== null &&
+    'then' in value &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function formatValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return value.stack ?? value.message;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function abortMessage(signal: AbortSignal): string {
+  return typeof signal.reason === 'string' ? signal.reason : 'Code execution cancelled';
+}
+
+function formatDuration(ms: number): string {
+  return ms % 60_000 === 0 ? `${ms / 60_000} minute(s)` : `${ms}ms`;
+}
+
+class TerminalError extends Error {
+  constructor(
+    readonly status: 'timeout' | 'cancelled',
+    message: string,
+  ) {
+    super(message);
+  }
+}

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -18,9 +18,11 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { botManager } from './api/index.js';
 import { formatWorldState } from '../sdk/formatter.js';
+import { executeCode, PerBotQueue } from './execution.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
+const executionQueue = new PerBotQueue();
 
 // Create MCP server
 const server = new Server(
@@ -169,98 +171,49 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
         }
 
         const isLongCode = code.length > 2000;
-
-        // Capture console output BEFORE connecting to prevent SDK logs from corrupting MCP JSON-RPC stdout
-        const logs: string[] = [];
-        const originalLog = console.log;
-        const originalWarn = console.warn;
-        const originalError = console.error;
-
-        console.log = (...args) => logs.push(args.map(a => typeof a === 'object' ? JSON.stringify(a, null, 2) : String(a)).join(' '));
-        console.warn = (...args) => logs.push('[warn] ' + args.map(a => typeof a === 'object' ? JSON.stringify(a, null, 2) : String(a)).join(' '));
-        // Don't capture console.error - let it go to stderr for MCP debugging
-
-        // Auto-connect if not already connected
-        let connection = botManager.get(botName);
-        if (!connection) {
-          console.error(`[MCP] Bot "${botName}" not connected, auto-connecting...`);
-          connection = await botManager.connect(botName);
-          // Wait up to 15s for initial world state after fresh connection
-          try {
-            await connection.sdk.waitForCondition(() => connection!.sdk.getState() !== null, 15000);
-          } catch {
-            console.error(`[MCP] Warning: initial state not received within 15s for bot "${botName}"`);
-          }
-        }
-
-        try {
-          const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-          const fn = new AsyncFunction('bot', 'sdk', code);
-
-          // Execute code with configurable timeout + MCP cancellation signal
-          const timeoutMinutes = Math.min(Math.max((args?.timeout as number) || 2, 0.1), 60);
-          const EXECUTION_TIMEOUT = timeoutMinutes * 60 * 1000;
-          let timeoutId: ReturnType<typeof setTimeout>;
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => reject(new Error(`Code execution timed out after ${timeoutMinutes} minute(s)`)), EXECUTION_TIMEOUT);
-          });
-
-          // AbortController that fires on MCP cancellation
-          const abortController = new AbortController();
-          const signal = abortController.signal;
-
-          if (extra.signal) {
-            if (extra.signal.aborted) {
-              abortController.abort(extra.signal.reason);
-            } else {
-              extra.signal.addEventListener('abort', () => {
-                console.error(`[MCP] execute_code cancelled by client for bot "${botName}"`);
-                abortController.abort('Cancelled by client');
-              }, { once: true });
+        return executionQueue.run(botName, async () => {
+          // Connecting is part of the serialized session so concurrent first
+          // calls cannot create duplicate controllers for the same bot.
+          let connection = botManager.get(botName);
+          if (!connection) {
+            console.error(`[MCP] Bot "${botName}" not connected, auto-connecting...`);
+            connection = await botManager.connect(botName);
+            try {
+              await connection.sdk.waitForCondition(
+                () => connection!.sdk.getState() !== null,
+                15000,
+              );
+            } catch {
+              console.error(`[MCP] Warning: initial state not received within 15s for bot "${botName}"`);
             }
           }
 
-          const cancelPromise = new Promise<never>((_, reject) => {
-            signal.addEventListener('abort', () => {
-              reject(new Error(typeof signal.reason === 'string' ? signal.reason : 'Code execution cancelled'));
-            }, { once: true });
+          const timeoutMinutes = Math.min(
+            Math.max((args?.timeout as number) || 2, 0.1),
+            60,
+          );
+          const outcome = await executeCode({
+            bot: connection.bot,
+            sdk: connection.sdk,
+            code,
+            timeoutMs: timeoutMinutes * 60_000,
+            signal: extra.signal,
           });
-
-          // Wrap bot and sdk in proxies that throw on every method call once cancelled
-          const cancellable = <T extends object>(target: T): T =>
-            new Proxy(target, {
-              get(obj, prop, receiver) {
-                const value = Reflect.get(obj, prop, receiver);
-                if (typeof value === 'function') {
-                  return (...args: any[]) => {
-                    if (signal.aborted) throw new Error('Execution cancelled');
-                    return value.apply(obj, args);
-                  };
-                }
-                return value;
-              }
-            });
-
-          let result: any;
-          try {
-            result = await Promise.race([fn(cancellable(connection.bot), cancellable(connection.sdk)), timeoutPromise, cancelPromise]);
-          } finally {
-            clearTimeout(timeoutId!);
-            if (!signal.aborted) abortController.abort('Execution finished');
-          }
-
-          // Build formatted output
           const parts: string[] = [];
 
-          if (logs.length > 0) {
+          if (outcome.logs.length > 0) {
             parts.push('── Console ──');
-            parts.push(logs.join('\n'));
+            parts.push(outcome.logs.join('\n'));
           }
 
-          if (result !== undefined) {
-            if (logs.length > 0) parts.push('');
+          if (outcome.status === 'success' && outcome.result !== undefined) {
+            if (parts.length > 0) parts.push('');
             parts.push('── Result ──');
-            parts.push(JSON.stringify(result, null, 2));
+            parts.push(stringifyResult(outcome.result));
+          } else if (outcome.status !== 'success') {
+            if (parts.length > 0) parts.push('');
+            parts.push(`── ${outcome.status.toUpperCase()} ──`);
+            parts.push(outcome.error ?? 'Execution failed');
           }
 
           // Append formatted world state. The connection's tick cursor
@@ -298,15 +251,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
           }
 
           const output = parts.length > 0 ? parts.join('\n') : '(no output)';
-
           return {
-            content: [{ type: 'text', text: output }]
+            value: {
+              content: [{ type: 'text' as const, text: output }],
+              ...(outcome.status === 'success' ? {} : { isError: true }),
+            },
+            holdUntil: outcome.quiescence,
           };
-        } finally {
-          console.log = originalLog;
-          console.warn = originalWarn;
-          console.error = originalError;
-        }
+        }, extra.signal);
       }
 
       default:
@@ -334,8 +286,25 @@ function errorResponse(message: string) {
   };
 }
 
+function stringifyResult(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function keepStdioProtocolClean(): void {
+  // stdout belongs to MCP JSON-RPC. User code receives a scoped console;
+  // process and SDK diagnostics go to stderr.
+  console.log = (...args: unknown[]) => console.error(...args);
+  console.info = (...args: unknown[]) => console.error(...args);
+  console.debug = (...args: unknown[]) => console.error(...args);
+}
+
 // Start server
 async function main() {
+  keepStdioProtocolClean();
   console.error('[MCP Server] Starting RS-Agent MCP server v2.0...');
   console.error('[MCP Server] Bots auto-connect on the first execute_code call.');
 

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"],
+    "noEmit": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": []
+}

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "server",
   "private": true,
   "scripts": {
-    "check": "bun run typecheck && bun run typecheck:webclient && bun run test:focused && bun run docs:api:check",
+    "check": "bun run typecheck && bun run typecheck:webclient && bun run typecheck:mcp && bun run test:focused && bun run docs:api:check",
     "docs:api": "bun sdk/generate-api-docs.ts",
     "docs:api:check": "bun sdk/generate-api-docs.ts --check",
     "fetch-collision-data": "bun sdk/fetch-collision-data.ts",
     "test:docs": "bun test sdk/test/api-docs.test.ts sdk/test/docs-snippets.test.ts",
-    "test:focused": "bun sdk/test/chat-history.test.ts && bun sdk/test/click-dialog-by-text.test.ts && bun run test:docs",
+    "test:focused": "bun sdk/test/chat-history.test.ts && bun sdk/test/click-dialog-by-text.test.ts && bun run test:docs && bun run test:mcp",
+    "test:mcp": "bun test mcp/execution.test.ts",
     "typecheck": "tsc --noEmit",
+    "typecheck:mcp": "tsc --noEmit -p mcp/tsconfig.json",
     "typecheck:webclient": "tsc --noEmit -p server/webclient/tsconfig.json"
   },
   "devDependencies": {

--- a/sdk/API.md
+++ b/sdk/API.md
@@ -174,6 +174,7 @@
 | `getPrayerState(): PrayerState \| null` | Get current prayer state from world state. |
 | `isPrayerActive(prayer: PrayerName \| number): boolean` | Check if a specific prayer is currently active. |
 | `getActivePrayers(): PrayerName[]` | Get list of all currently active prayer names. |
+| `isDoorTemporarilyBlocked(level: number, x: number, z: number): boolean` | Check this SDK session's non-expired temporary door evidence. |
 
 ### Other
 
@@ -181,6 +182,8 @@
 |---|---|
 | `async checkBotStatus(): Promise<BotStatus>` | Check bot status via gateway HTTP endpoint. Returns info about whether bot is connected and who else is controlling/observing. |
 | `async launchBrowser(): Promise<void>` | Launch native browser to client URL. Uses the `open` package for cross-platform support (macOS, Windows, Linux, WSL). Falls back to printing the URL if no browser can be opened. |
+| `countInventoryItems(pattern: string \| RegExp): number` | Count total item quantity matching a name pattern. This sums stack sizes across every matching slot. Use `getInventory().filter(...)` when the number of occupied slots is needed. |
+| `blockDoorTemporarily(level: number, x: number, z: number, ttlMs: number = 30_000): boolean` | Temporarily exclude a known door from this SDK instance's path queries. The shared collision map is never mutated beyond the synchronous query. |
 
 ### Condition Waiting
 
@@ -295,6 +298,14 @@ interface PlayerState {
   spotanimId: number;
   /** Combat state tracking */
   combat: PlayerCombatState;
+  /** True while the player's hitpoints are zero. */
+  isDead: boolean;
+  /** Changes after each observed death/respawn cycle. */
+  lifeId: number;
+  /** Number of respawns observed during this client session. */
+  respawnCount: number;
+  /** Public game tick when death was last observed, or null if none was observed. */
+  lastDeathTick: number | null;
 }
 ```
 
@@ -390,6 +401,8 @@ interface PrayerResult {
 ```typescript
 interface BotWorldState {
   tick: number;
+  /** Monotonic state publication cursor; advances even for multiple publications in one game tick. */
+  revision?: number;
   inGame: boolean;
   player: PlayerState | null;
   skills: SkillState[];
@@ -423,6 +436,8 @@ interface ActionResult {
   data?: any;
   /** Machine-readable failure category (e.g. 'cant_reach', 'no_match', 'timeout') */
   reason?: string;
+  /** Primitive actions report dispatch; porcelain actions may report observation/completion. */
+  phase?: 'validation' | 'routing' | 'dispatch' | 'observation' | 'completion';
 }
 ```
 
@@ -540,7 +555,7 @@ interface EatResult {
 interface AttackResult {
   success: boolean;
   message: string;
-  reason?: 'npc_not_found' | 'no_attack_option' | 'out_of_reach' | 'already_in_combat' | 'timeout';
+  reason?: 'npc_not_found' | 'no_attack_option' | 'out_of_reach' | 'already_in_combat' | 'died' | 'timeout';
 }
 ```
 


### PR DESCRIPTION
## Summary
- run `execute_code` in a per-bot FIFO while allowing different bots to proceed concurrently
- stop timed-out or cancelled programs from starting new SDK calls
- keep the bot lock until SDK calls that already started have settled
- use a request-scoped console so concurrent sessions do not overwrite process globals, while routing SDK diagnostics away from MCP stdout
- preserve TypeScript bodies, bounded logs, partial error output, and the terminal world-state snapshot

## Deliberately omitted from #44
No structured inspect/query/action tools, session-health metadata, resource abstraction, connection-manager rewrite, or separate output framework. This is the smallest slice that prevents agent programs from interleaving mutations.

## Validation
- `bun run check`
- 7 focused MCP execution/FIFO tests pass
- MCP TypeScript check passes
- MCP initialize handshake passes over stdio
- generated `sdk/API.md` is refreshed for already-merged #45 (17-line post-merge drift fix)

## Boundary
`execute_code` remains trusted, unsandboxed execution. CPU-bound synchronous code cannot be pre-empted. An SDK call that already started cannot be force-aborted, so the next same-bot session intentionally waits for it to settle.

Supersedes #44.
