### PR TITLE
fix(sdk): report dropped action dispatches instead of throwing

### DIFF
--- a/sdk/API.md
+++ b/sdk/API.md
@@ -701,7 +701,8 @@ interface PickpocketResult {
   success: boolean;
   message: string;
   xpGained?: number;
-  reason?: 'npc_not_found' | 'no_pickpocket_option' | 'cant_reach' | 'stunned' | 'timeout';
+  /** 'dispatch_failed' = the interaction never reached the game (client stalled or dropped it). */
+  reason?: 'npc_not_found' | 'no_pickpocket_option' | 'cant_reach' | 'stunned' | 'timeout' | 'dispatch_failed';
 }
 ```
 

--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -2877,7 +2877,13 @@ export class BotActions {
 
         const result = await this.sdk.sendInteractNpc(npc.index, pickOpt.opIndex);
         if (!result.success) {
-            return { success: false, message: result.message, reason: 'timeout' };
+            // Not retried by withDoorRetry: a dropped dispatch means the client
+            // stalled, and re-sending just burns another actionTimeout.
+            return {
+                success: false,
+                message: `Pickpocket dispatch failed on ${npc.name}: ${result.message}`,
+                reason: 'dispatch_failed'
+            };
         }
 
         try {

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -69,6 +69,19 @@ interface PendingAction {
     timeout: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * A dispatch that never produced a result: the browser client didn't answer in
+ * time, the socket closed mid-flight, or the gateway reported an error.
+ * sendAction converts these into failed ActionResults so a single dropped
+ * action reports itself instead of killing the caller's script.
+ */
+class ActionDispatchError extends Error {
+    constructor(message: string, readonly reason: 'timeout' | 'disconnected' | 'error') {
+        super(message);
+        this.name = 'ActionDispatchError';
+    }
+}
+
 interface PendingScreenshot {
     resolve: (dataUrl: string) => void;
     reject: (error: Error) => void;
@@ -229,7 +242,7 @@ export class BotSDK {
 
                 for (const [actionId, pending] of this.pendingActions) {
                     clearTimeout(pending.timeout);
-                    pending.reject(new Error('Connection closed'));
+                    pending.reject(new ActionDispatchError('Connection closed', 'disconnected'));
                 }
                 this.pendingActions.clear();
 
@@ -953,22 +966,34 @@ export class BotSDK {
 
         const actionId = `act-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
-        return new Promise((resolve, reject) => {
-            const timeout = setTimeout(() => {
-                this.pendingActions.delete(actionId);
-                reject(new Error(`Action timed out: ${action.type}`));
-            }, this.config.actionTimeout);
+        try {
+            return await new Promise<ActionResult>((resolve, reject) => {
+                const timeout = setTimeout(() => {
+                    this.pendingActions.delete(actionId);
+                    reject(new ActionDispatchError(`Action timed out: ${action.type}`, 'timeout'));
+                }, this.config.actionTimeout);
 
-            this.pendingActions.set(actionId, { resolve, reject, timeout });
+                this.pendingActions.set(actionId, { resolve, reject, timeout });
 
-            this.send({
-                type: 'sdk_action',
-                username: this.config.botUsername,
-                actionId,
-                action,
-                actionTimeoutMs: this.config.actionTimeout
+                this.send({
+                    type: 'sdk_action',
+                    username: this.config.botUsername,
+                    actionId,
+                    action,
+                    actionTimeoutMs: this.config.actionTimeout
+                });
             });
-        });
+        } catch (err) {
+            // A dropped dispatch is a reportable failure, not a fatal one: callers
+            // check result.success and can retry, reposition, or give up. Losing
+            // the connection outright still throws from the guard above.
+            return {
+                success: false,
+                message: err instanceof Error ? err.message : String(err),
+                reason: err instanceof ActionDispatchError ? err.reason : 'error',
+                phase: 'dispatch'
+            };
+        }
     }
 
     /** Send walk command to coordinates. */
@@ -1639,7 +1664,7 @@ export class BotSDK {
                 if (message.result) {
                     pending.resolve(message.result);
                 } else {
-                    pending.reject(new Error('No result in action response'));
+                    pending.reject(new ActionDispatchError('No result in action response', 'error'));
                 }
             }
         }
@@ -1656,7 +1681,7 @@ export class BotSDK {
                 if (pending) {
                     clearTimeout(pending.timeout);
                     this.pendingActions.delete(message.actionId);
-                    pending.reject(new Error(message.error || 'Unknown error'));
+                    pending.reject(new ActionDispatchError(message.error || 'Unknown error', 'error'));
                 }
             }
             if (message.screenshotId) {

--- a/sdk/test/action-dispatch-failure.test.ts
+++ b/sdk/test/action-dispatch-failure.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { BotSDK } from '../index';
+import type { ActionResult } from '../types';
+
+/**
+ * Build an SDK that looks connected but whose socket swallows everything, so a
+ * dispatch never gets a result back.
+ */
+function stubSdk(actionTimeout: number) {
+    const sdk = Object.create(BotSDK.prototype) as BotSDK;
+    const sent: any[] = [];
+    (sdk as any).config = { actionTimeout, botUsername: 'tester' };
+    (sdk as any).connectionState = 'connected';
+    (sdk as any).pendingActions = new Map();
+    (sdk as any).ws = { readyState: WebSocket.OPEN };
+    (sdk as any).send = (msg: any) => sent.push(msg);
+    return { sdk, sent, pending: (sdk as any).pendingActions as Map<string, any> };
+}
+
+function dispatch(sdk: BotSDK): Promise<ActionResult> {
+    return (sdk as any).sendAction({ type: 'walkTo', x: 0, z: 0, running: true, reason: 'SDK' });
+}
+
+describe('BotSDK.sendAction dispatch failures', () => {
+    test('reports a timeout instead of throwing', async () => {
+        const { sdk, sent, pending } = stubSdk(20);
+
+        const result = await dispatch(sdk);
+
+        expect(sent).toHaveLength(1);
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('timeout');
+        expect(result.phase).toBe('dispatch');
+        expect(result.message).toContain('walkTo');
+        expect(pending.size).toBe(0);
+    });
+
+    test('reports a mid-flight disconnect instead of throwing', async () => {
+        const { sdk, pending } = stubSdk(5000);
+
+        const promise = dispatch(sdk);
+        const entry = [...pending.values()][0]!;
+        clearTimeout(entry.timeout);
+        entry.reject(new Error('Connection closed'));
+
+        const result = await promise;
+        expect(result.success).toBe(false);
+        expect(result.message).toBe('Connection closed');
+    });
+
+    test('reports a gateway error instead of throwing', async () => {
+        const { sdk, sent } = stubSdk(5000);
+
+        const promise = dispatch(sdk);
+        (sdk as any).handleMessage(JSON.stringify({
+            type: 'sdk_error',
+            actionId: sent[0].actionId,
+            error: 'Bot not connected to gateway'
+        }));
+
+        const result = await promise;
+        expect(result.success).toBe(false);
+        expect(result.reason).toBe('error');
+        expect(result.message).toBe('Bot not connected to gateway');
+    });
+
+    test('still resolves normally when a result arrives', async () => {
+        const { sdk, sent, pending } = stubSdk(5000);
+
+        const promise = dispatch(sdk);
+        const actionId = sent[0].actionId;
+        (sdk as any).handleMessage(JSON.stringify({
+            type: 'sdk_action_result',
+            actionId,
+            result: { success: true, message: 'Walking' }
+        }));
+
+        expect(await promise).toEqual({ success: true, message: 'Walking' });
+        expect(pending.size).toBe(0);
+    });
+});

--- a/sdk/types.ts
+++ b/sdk/types.ts
@@ -644,7 +644,8 @@ export interface PickpocketResult {
     success: boolean;
     message: string;
     xpGained?: number;
-    reason?: 'npc_not_found' | 'no_pickpocket_option' | 'cant_reach' | 'stunned' | 'timeout';
+    /** 'dispatch_failed' = the interaction never reached the game (client stalled or dropped it). */
+    reason?: 'npc_not_found' | 'no_pickpocket_option' | 'cant_reach' | 'stunned' | 'timeout' | 'dispatch_failed';
 }
 
 export interface CraftJewelryResult {


### PR DESCRIPTION
sendAction rejected on four paths - dispatch timeout, socket close mid-flight, gateway sdk_error, and a missing result payload. Porcelain actions dispatch outside their try blocks, so those rejections escaped past the `if (!result.success)` branches written to handle them and killed the caller's script. bot.pickpocketNpc() advertised a reason: 'timeout' it could never actually return; a thieving run died on the first stalled dispatch instead of retrying.

sendAction now resolves { success: false, reason, phase: 'dispatch' }, tagging each rejection site via ActionDispatchError so callers can tell a timeout from a disconnect from a gateway error. The pre-flight "Not connected" guard still throws: a dead connection should stop a script, not let it spin.

pickpocketNpc reports the dispatch failure as 'dispatch_failed' rather than 'timeout' - withDoorRetry retries on 'timeout', which would have cost 3x actionTimeout per call against a stalled client.