### PR TITLE
feat(sdk): print a compact state summary after script runs

### DIFF
--- a/sdk/formatter.ts
+++ b/sdk/formatter.ts
@@ -18,6 +18,125 @@ function formatAge(ms: number): string {
 }
 
 /**
+ * Format world state as a handful of lines: position, vitals, XP gained,
+ * inventory, anything blocking, and the last few messages.
+ * Used for the post-script snapshot, where a full dump buries script output.
+ * `options.xpBefore` maps skill name -> xp at script start; only skills that
+ * moved are listed.
+ */
+export function formatWorldStateSummary(
+    state: BotWorldState,
+    stateAgeMs?: number,
+    options?: { xpBefore?: Record<string, number> }
+): string {
+    const lines: string[] = [];
+    const stale = stateAgeMs !== undefined && stateAgeMs > 5000 ? ` | state ${formatAge(stateAgeMs)}` : '';
+
+    const p = state.player;
+    if (p) {
+        const hp = (state.skills || []).find(s => s.name === 'Hitpoints');
+        const hpStr = hp ? ` | HP ${hp.level}/${hp.baseLevel}` : '';
+        const dead = p.isDead ? ' | DEAD' : '';
+        let combat = '';
+        if (p.combat.inCombat) {
+            const target = state.nearbyNpcs.find(n => n.index === p.combat.targetIndex);
+            combat = ` | fighting ${target?.name ?? `idx ${p.combat.targetIndex}`}`;
+        }
+        lines.push(`Pos (${p.worldX}, ${p.worldZ})${p.level ? ` lvl ${p.level}` : ''}${hpStr}${dead}${combat}${stale}`);
+    } else {
+        lines.push(`Not in game (tick ${state.tick})${stale}`);
+    }
+
+    // XP gained during the script - the usual "did it work?" signal
+    if (options?.xpBefore) {
+        const gains: string[] = [];
+        for (const skill of state.skills || []) {
+            const before = options.xpBefore[skill.name];
+            if (before === undefined) continue;
+            const delta = skill.experience - before;
+            if (delta > 0) gains.push(`${skill.name} +${delta.toLocaleString()}`);
+        }
+        lines.push(gains.length > 0 ? `XP: ${gains.join(', ')}` : 'XP: none gained');
+    }
+
+    // Inventory as one line, most-of-the-time short enough to scan
+    const inv = state.inventory || [];
+    const counts = new Map<string, number>();
+    for (const item of inv) counts.set(item.name, (counts.get(item.name) ?? 0) + item.count);
+    const entries = [...counts].map(([name, count]) => (count > 1 ? `${name} x${count}` : name));
+    const shown = entries.slice(0, 8).join(', ');
+    const more = entries.length > 8 ? `, +${entries.length - 8} more` : '';
+    lines.push(`Inv ${inv.length}/28: ${entries.length > 0 ? shown + more : '(empty)'}`);
+
+    // Nearby entities, deduped by name (nearest distance wins) and capped -
+    // enough to see where you are, not the full scene graph
+    const nearbyLine = (
+        label: string,
+        entries: { name: string; distance: number }[],
+        limit = 5
+    ): string | null => {
+        if (entries.length === 0) return null;
+        const byName = new Map<string, { count: number; distance: number }>();
+        for (const e of entries) {
+            const existing = byName.get(e.name);
+            if (existing) {
+                existing.count++;
+                existing.distance = Math.min(existing.distance, e.distance);
+            } else {
+                byName.set(e.name, { count: 1, distance: e.distance });
+            }
+        }
+        const sorted = [...byName].sort((a, b) => a[1].distance - b[1].distance);
+        const shown = sorted.slice(0, limit)
+            .map(([name, d]) => `${name}${d.count > 1 ? ` x${d.count}` : ''} (${d.distance}t)`);
+        const more = sorted.length > limit ? ` +${sorted.length - limit} more` : '';
+        return `${label}: ${shown.join(', ')}${more}`;
+    };
+
+    const nearby = [
+        nearbyLine('NPCs', state.nearbyNpcs || []),
+        nearbyLine('Objs', state.nearbyLocs || []),
+        nearbyLine('Ground', (state.groundItems || []).map(g => ({
+            name: g.count > 1 ? `${g.name} x${g.count}` : g.name,
+            distance: g.distance
+        })), 4),
+        nearbyLine('Players', state.nearbyPlayers || [], 3)
+    ].filter((line): line is string => line !== null);
+    lines.push(...nearby);
+
+    // Anything that would block the next script
+    const blockers: string[] = [];
+    if (state.dialog?.isOpen) {
+        const opts = state.dialog.options.length;
+        blockers.push(`dialog open${opts > 0 ? ` (${opts} options)` : ''}`);
+    }
+    if (state.bank?.isOpen) blockers.push('bank open');
+    if (state.shop?.isOpen) blockers.push(`shop open (${state.shop.title})`);
+    if (state.interface?.isOpen && !state.bank?.isOpen && !state.shop?.isOpen) {
+        blockers.push(`interface ${state.interface.interfaceId} open`);
+    } else if (state.modalOpen && !state.dialog?.isOpen) {
+        blockers.push(`modal ${state.modalInterface} open`);
+    }
+    if (blockers.length > 0) lines.push(`[!] ${blockers.join(', ')}`);
+
+    // Last few messages - "I can't reach that" lives here
+    const stripCodes = (s: string) => s.replace(/@\w+@/g, '');
+    const recent = (state.gameMessages || []).slice(-40).filter(m => !m.fromSelf);
+    const collapsed: { text: string; count: number }[] = [];
+    for (const msg of recent) {
+        const text = (isPlayerChat(msg.type) && msg.sender ? `${msg.sender}: ` : '') + stripCodes(msg.text);
+        const last = collapsed[collapsed.length - 1];
+        if (last && last.text === text) last.count++;
+        else collapsed.push({ text, count: 1 });
+    }
+    for (const msg of collapsed.slice(-3)) {
+        lines.push(`> ${msg.text}${msg.count > 1 ? ` (x${msg.count})` : ''}`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
  * Format world state as readable plaintext/markdown.
  * `options.sinceTick`: only render gameMessages with tick > sinceTick.
  * The MCP server passes this to suppress chat the bot has already been shown

--- a/sdk/runner.ts
+++ b/sdk/runner.ts
@@ -3,7 +3,7 @@
 
 import { BotSDK, deriveGatewayUrl } from './index';
 import { BotActions } from './actions';
-import { formatWorldState } from './formatter';
+import { formatWorldStateSummary } from './formatter';
 import type { BotWorldState } from './types';
 import { readFileSync, existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
@@ -34,7 +34,11 @@ export interface RunOptions {
     autoConnect?: boolean;
     /** Disconnect when done (default: false) */
     disconnectAfter?: boolean;
-    /** Print world state after execution (default: true) */
+    /**
+     * Print a short state summary after execution (default: true) -
+     * position, XP gained, inventory, anything blocking, last few messages.
+     * Run `bun sdk/cli.ts {username}` for the full world state.
+     */
     printState?: boolean;
     /**
      * How to handle bot client disconnection during script execution:
@@ -261,6 +265,12 @@ export async function runScript(
         sdk,
     };
 
+    // Baseline XP so the summary can report what the script actually earned
+    const xpBefore: Record<string, number> = {};
+    for (const skill of sdk.getState()?.skills ?? []) {
+        xpBefore[skill.name] = skill.experience;
+    }
+
     // Clean exit on signals - prevents orphaned processes when parent shell is killed
     let signalReceived = false;
     const signalCleanup = (signal: string) => {
@@ -361,21 +371,22 @@ export async function runScript(
         console.log(typeof result === 'object' ? JSON.stringify(result, null, 2) : String(result));
     }
 
-    // Print error if any
+    // Print error if any. Also fail the process so `bun script.ts` exits non-zero.
     if (error) {
         console.log('');
-        console.log('── Error ──');
-        console.log(error.message);
-        if (error.stack) {
-            console.log(error.stack);
+        console.log(`── Error ── ${error.name}: ${error.message}`);
+        // First few frames are enough to locate it
+        for (const frame of (error.stack ?? '').split('\n').slice(1, 5)) {
+            console.log(frame);
         }
+        if (managedConnection) process.exitCode = 1;
     }
 
     // Print state if requested
     if (printState && finalState) {
         console.log('');
-        console.log('── World State ──');
-        console.log(formatWorldState(finalState, sdk.getStateAge()));
+        console.log('── State ──');
+        console.log(formatWorldStateSummary(finalState, sdk.getStateAge(), { xpBefore }));
     }
 
     // Disconnect if requested (only for managed connections)

--- a/sdk/test/state-summary.test.ts
+++ b/sdk/test/state-summary.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test';
+import { formatWorldStateSummary } from '../formatter';
+import type { BotWorldState } from '../types';
+
+function state(overrides: Partial<BotWorldState> = {}): BotWorldState {
+    return {
+        tick: 100,
+        inGame: true,
+        player: {
+            name: 'testbot',
+            worldX: 3222,
+            worldZ: 3218,
+            level: 0,
+            combatLevel: 3,
+            isDead: false,
+            lifeId: 1,
+            respawnCount: 0,
+            combat: { inCombat: false, targetIndex: -1 }
+        } as any,
+        skills: [
+            { name: 'Hitpoints', level: 7, baseLevel: 10, experience: 1300 },
+            { name: 'Woodcutting', level: 5, baseLevel: 5, experience: 500 }
+        ] as any,
+        inventory: [],
+        equipment: [],
+        nearbyNpcs: [],
+        nearbyPlayers: [],
+        nearbyLocs: [],
+        groundItems: [],
+        gameMessages: [],
+        recentDialogs: [],
+        dialog: { isOpen: false, isWaiting: false, options: [] } as any,
+        interface: { isOpen: false, interfaceId: -1, options: [] } as any,
+        shop: { isOpen: false, title: '', shopItems: [], playerItems: [] } as any,
+        bank: { isOpen: false, items: [] } as any,
+        modalOpen: false,
+        modalInterface: -1,
+        combatEvents: [],
+        prayers: { activePrayers: [], prayerPoints: 1, prayerLevel: 1 } as any,
+        ...overrides
+    };
+}
+
+describe('formatWorldStateSummary', () => {
+    test('stays short even for a busy world', () => {
+        const busy = state({
+            nearbyLocs: Array.from({ length: 120 }, (_, i) => ({ name: `Tree ${i}`, x: i, z: i, distance: i, options: ['Chop down'] })) as any,
+            nearbyNpcs: Array.from({ length: 30 }, (_, i) => ({ name: `Man ${i}`, index: i, distance: i, combatLevel: 2, hp: null, maxHp: null, inCombat: false, options: ['Talk-to'] })) as any,
+            groundItems: Array.from({ length: 20 }, (_, i) => ({ name: `Item ${i}`, count: 1, x: i, z: i, distance: i })) as any
+        });
+
+        const out = formatWorldStateSummary(busy, 0);
+
+        expect(out.split('\n').length).toBeLessThanOrEqual(8);
+        expect(out).toContain('Pos (3222, 3218)');
+        expect(out).toContain('HP 7/10');
+        expect(out).toContain('Objs: Tree 0 (0t)');
+        expect(out).toContain('+115 more');
+        expect(out).toContain('+25 more');
+        expect(out).toContain('+16 more');
+    });
+
+    test('groups nearby entities by name, nearest first', () => {
+        const world = state({
+            nearbyLocs: [
+                { name: 'Oak', x: 0, z: 0, distance: 6, options: [] },
+                { name: 'Tree', x: 0, z: 0, distance: 4, options: [] },
+                { name: 'Tree', x: 0, z: 0, distance: 2, options: [] }
+            ] as any,
+            groundItems: [{ name: 'Coins', count: 34, x: 0, z: 0, distance: 1 }] as any,
+            nearbyPlayers: [{ name: 'Zezima', combatLevel: 126, distance: 4 }] as any
+        });
+
+        const out = formatWorldStateSummary(world, 0);
+
+        expect(out).toContain('Objs: Tree x2 (2t), Oak (6t)');
+        expect(out).toContain('Ground: Coins x34 (1t)');
+        expect(out).toContain('Players: Zezima (4t)');
+        expect(out).not.toContain('NPCs:');
+    });
+
+    test('reports xp gained per skill', () => {
+        const out = formatWorldStateSummary(state(), 0, {
+            xpBefore: { Hitpoints: 1300, Woodcutting: 220 }
+        });
+
+        expect(out).toContain('XP: Woodcutting +280');
+    });
+
+    test('reports no xp when nothing moved', () => {
+        const out = formatWorldStateSummary(state(), 0, {
+            xpBefore: { Hitpoints: 1300, Woodcutting: 500 }
+        });
+
+        expect(out).toContain('XP: none gained');
+    });
+
+    test('summarizes inventory and truncates long lists', () => {
+        const inv = state({
+            inventory: [
+                { slot: 0, id: 1, name: 'Coins', count: 543, optionsWithIndex: [] },
+                ...Array.from({ length: 10 }, (_, i) => ({ slot: i + 1, id: i + 2, name: `Item ${i}`, count: 1, optionsWithIndex: [] }))
+            ] as any
+        });
+
+        const out = formatWorldStateSummary(inv, 0);
+
+        expect(out).toContain('Inv 11/28: Coins x543');
+        expect(out).toContain('+3 more');
+    });
+
+    test('flags blocking UI and shows the last few messages', () => {
+        const blocked = state({
+            dialog: { isOpen: true, isWaiting: false, options: [{ index: 1, text: 'Yes' }] } as any,
+            gameMessages: [
+                { tick: 1, text: 'You get some logs.', type: 0, sender: null, fromSelf: false },
+                { tick: 2, text: "I can't reach that!", type: 0, sender: null, fromSelf: false },
+                { tick: 3, text: "I can't reach that!", type: 0, sender: null, fromSelf: false }
+            ] as any
+        });
+
+        const out = formatWorldStateSummary(blocked, 0);
+
+        expect(out).toContain('[!] dialog open (1 options)');
+        expect(out).toContain("> I can't reach that! (x2)");
+    });
+});


### PR DESCRIPTION
runScript dumped the full world state on exit - every skill, 10 NPCs, 10 objects, ground items - which buried the script's own console.log output. Replace it with a few lines: position/vitals, XP gained during the run, inventory, nearby entities grouped by name, anything blocking, and the last few messages.

XP is a delta against a baseline snapshotted before the script starts, so "did it work?" is answerable from the first two lines.

Errors now print the message plus four stack frames instead of the whole stack, and set process.exitCode = 1 so a failed run is detectable without grepping the output.

formatWorldState() is unchanged and still used by sdk/cli.ts and the MCP server for full-state queries.