### PR TITLE
fix(sdk): make interface closing work and fletching pick the right product

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -148,6 +148,8 @@ For the complete method reference, see **[sdk/API.md](sdk/API.md)** (auto-genera
 | `openBank()` | Open nearest bank |
 | `depositItem(target, amount?)` | Deposit item to bank |
 | `withdrawItem(slot, amount?)` | Withdraw item from bank |
+| `closeInterface()` | Close any open modal (shop, bank, book, quest scroll) |
+| `closeShop()` / `closeBank()` | Close the shop / bank interface |
 | `openShop(target?)` | Open shop via shopkeeper NPC |
 | `buyFromShop(target, amount?)` | Buy item from open shop |
 | `sellToShop(target, amount?)` | Sell item to open shop |
@@ -174,8 +176,10 @@ For the complete method reference, see **[sdk/API.md](sdk/API.md)** (auto-genera
 | `findNearbyNpc(pattern)` / `findNearbyLoc(pattern)` | Find nearby entities |
 | `findGroundItem(pattern)` | Find ground items |
 | `getDialog()` | Current dialog state |
-| `sendClickDialog(option)` | Click dialog option |
+| `sendClickDialog(option)` | Click dialog option by its published `index` |
+| `clickDialogByText(pattern)` | Click dialog option by label — prefer this |
 | `sendClickComponent(id)` | Click interface button |
+| `sendCloseModal()` / `sendCloseShop()` | Close the open modal / shop |
 | `sendDropItem(slot)` | Drop inventory item |
 | `sendUseItem(slot)` | Use inventory item (bury, etc.) |
 | `sendUseItemOnItem(src, dst)` | Combine two items |
@@ -201,6 +205,34 @@ monitoring, avoid overlapping action programs on the same bot, and inspect
 `sdk.getStateAge()` before acting after a disconnect or long pause.
 
 ---
+
+### Modals Hide the Inventory
+
+A shop or bank modal replaces the inventory tab, so the server rejects
+inventory packets sent underneath it as "component not visible" — with no game
+message. Close the modal before doing anything else:
+
+```typescript
+await bot.closeInterface();   // any modal
+await bot.closeShop();        // shop specifically
+await sdk.sendCloseModal();   // low-level
+```
+
+Don't click the interface's own "Close Window" component id. It's a
+client-side close button with no server trigger; the SDK now routes those to a
+close for you, but the named methods above are what to reach for.
+
+### Dialog Options Are Not In Product Order
+
+Skill dialogs (fletching, crafting) publish four buttons *per product* — Make
+X, Make 10, Make 5, then one labelled with the product name. Arrow shafts are
+option 4 of 12, not option 1. Never assume ordering:
+
+```typescript
+const dialog = sdk.getDialog();
+console.log(dialog?.options.map(o => `${o.index}: ${o.text}`));
+await sdk.clickDialogByText(/arrow shaft/i);   // or bot.fletchLogs('arrow shaft')
+```
 
 ### Dismiss Level-Up Dialogs
 

--- a/sdk/API.md
+++ b/sdk/API.md
@@ -105,7 +105,7 @@
 
 | Signature | Description |
 |---|---|
-| `async fletchLogs(product?: string): Promise<FletchResult>` | Fletch logs into bows or arrow shafts using a knife. |
+| `async fletchLogs(product?: string): Promise<FletchResult>` | Fletch logs into bows or arrow shafts using a knife. `product` is matched against the dialog's visible product labels ("15 Arrow Shafts", "Oak Short Bow", ...), so 'arrow shaft', 'shortbow' and 'oak long' all resolve. Omit it to take the first product offered. One call makes one batch — 15 shafts, or one bow. |
 | `async craftLeather(product?: string): Promise<CraftLeatherResult>` | Craft leather into armour using needle and thread. |
 | `async smithAtAnvil(product: string \| number = 'dagger', options: { barPattern?: RegExp; timeout?: number } = {}): Promise<SmithResult>` | Smith a bar into an item at an anvil. |
 | `async craftJewelry(options: { barPattern?: RegExp; product?: string; gem?: string; timeout?: number; } = {}): Promise<CraftJewelryResult>` | Craft jewelry at a furnace using a gold/silver bar and optional gem. Requires: bar + mould in inventory (ring mould, necklace mould, or amulet mould). Optionally a gem for gem-set jewelry. |
@@ -221,7 +221,7 @@
 | `async sendUseItem(slot: number, option: number = 1): Promise<ActionResult>` | Use an inventory item (eat, equip, etc). |
 | `async sendUseEquipmentItem(slot: number, option: number = 1): Promise<ActionResult>` | Use an equipped item (remove, operate, etc). |
 | `async sendDropItem(slot: number): Promise<ActionResult>` | Drop an inventory item. |
-| `async sendUseItemOnItem(sourceSlot: number, targetSlot: number): Promise<ActionResult>` | Use one inventory item on another. |
+| `async sendUseItemOnItem(sourceSlot: number, targetSlot: number): Promise<ActionResult>` | Use one inventory item on another. Rejected up front while a shop or bank modal is open: those replace the inventory tab, so the server drops the packet as "component not visible" and sends no message at all. Close the modal first — `bot.closeShop()`, `bot.closeInterface()`, or `sendCloseModal()`. |
 | `async sendUseItemOnLoc(itemSlot: number, x: number, z: number, locId: number): Promise<ActionResult>` | Use an inventory item on a location. |
 | `async sendUseItemOnNpc(itemSlot: number, npcIndex: number): Promise<ActionResult>` | Use an inventory item on an NPC. |
 | `async sendClickDialog(option: number = 0): Promise<ActionResult>` | Click a dialog option by its server-assigned index. IMPORTANT: `option` is the **server-assigned index** stored on each `DialogOption.index` field — NOT the array position in `dialog.options`. Server-assigned indices are 1-based: `dialog.options[0].index === 1`. Pass `0` only as the implicit "continue" click for dialogs with no selectable options (the common pattern: pass through narration pages). To click an option by its visible text, prefer `clickDialogByText()`, which avoids the index-vs-position footgun entirely. |

--- a/sdk/action-quantity.ts
+++ b/sdk/action-quantity.ts
@@ -1,4 +1,4 @@
-import type { InterfaceOption, InventoryItem } from './types';
+import type { DialogOption, InterfaceOption, InventoryItem } from './types';
 
 /**
  * Helpers for porcelain actions that take a quantity and expand it into
@@ -35,6 +35,49 @@ export function resolveInterfaceOption(
         return options.find(option => option.componentId === selector.componentId) ?? null;
     }
     return options.find(option => testPattern(selector, option.text)) ?? null;
+}
+
+/** "Make X", "Make 10", "Make 5", "Make 1" — quantity buttons, not products. */
+const QUANTITY_BUTTON = /^make\s+(x|\d+)$/i;
+
+/**
+ * Resolve a product in a skill dialog (`skill_multi2`..`skill_multi5`).
+ *
+ * These dialogs interleave four buttons per product — Make X, Make 10, Make 5,
+ * and a fourth whose label is the product name — so the product you want is
+ * never at the index its position in the menu suggests. Arrow shafts are
+ * option 4 of 12, not option 1. Only the make-1 button carries a name, so the
+ * named options *are* the products, in order.
+ *
+ * Matching is by visible label: every word of `product` must appear (so
+ * 'oak short' hits "Oak Short Bow"), falling back to a punctuation-insensitive
+ * contains (so 'shortbow' hits it too). Omit `product` for the first one.
+ */
+export function resolveSkillDialogProduct(
+    options: readonly DialogOption[],
+    product?: string,
+): DialogOption | null {
+    const named = options.filter(option => option.text && !QUANTITY_BUTTON.test(option.text.trim()));
+    if (named.length === 0) return null;
+    if (!product) return named[0] ?? null;
+
+    const wanted = product.toLowerCase().trim();
+    const words = wanted.split(/\s+/).filter(Boolean);
+    const byWords = named.find(option => {
+        const label = option.text.toLowerCase();
+        return words.every(word => label.includes(word));
+    });
+    if (byWords) return byWords;
+
+    const squash = (value: string) => value.toLowerCase().replace(/[^a-z0-9]/g, '');
+    return named.find(option => squash(option.text).includes(squash(wanted))) ?? null;
+}
+
+/** The product labels a skill dialog is offering, for error messages. */
+export function skillDialogProductLabels(options: readonly DialogOption[]): string[] {
+    return options
+        .filter(option => option.text && !QUANTITY_BUTTON.test(option.text.trim()))
+        .map(option => option.text);
 }
 
 /** Total count of an item across every inventory slot holding it. */

--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -50,6 +50,8 @@ import {
     countItems,
     nextShopStep,
     resolveInterfaceOption,
+    resolveSkillDialogProduct,
+    skillDialogProductLabels,
     validateActionQuantity,
     MAX_SHOP_ACTION_PACKETS,
     MAX_SHOP_ACTION_QUANTITY,
@@ -2026,9 +2028,29 @@ export class BotActions {
 
     // ============ Crafting & Fletching ============
 
-    /** Fletch logs into bows or arrow shafts using a knife. */
+    /**
+     * Fletch logs into bows or arrow shafts using a knife.
+     *
+     * `product` is matched against the dialog's visible product labels
+     * ("15 Arrow Shafts", "Oak Short Bow", ...), so 'arrow shaft', 'shortbow'
+     * and 'oak long' all resolve. Omit it to take the first product offered.
+     * One call makes one batch — 15 shafts, or one bow.
+     */
     async fletchLogs(product?: string): Promise<FletchResult> {
         await this.dismissBlockingUI();
+
+        // dismissBlockingUI deliberately leaves shop/bank modals alone, but the
+        // server hides the inventory component behind them: the use-item packet
+        // is dropped as "not visible" with no message at all, and the wait below
+        // would then match the modal that was already open. Fail loudly instead.
+        const preState = this.sdk.getState();
+        if (preState?.shop.isOpen || preState?.bank.isOpen) {
+            const blocker = preState.shop.isOpen ? 'shop' : 'bank';
+            return {
+                success: false,
+                message: `Cannot fletch with the ${blocker} interface open - close it first (bot.closeInterface()).`
+            };
+        }
 
         const knife = this.sdk.findInventoryItem(/knife/i);
         if (!knife) {
@@ -2040,11 +2062,7 @@ export class BotActions {
             return { success: false, message: 'No logs in inventory' };
         }
 
-        // Check if we're using oak or higher-tier logs (affects button order)
-        const isOakOrHigherLogs = /oak|willow|maple|yew|magic/i.test(logs.name);
-
         const fletchingBefore = this.sdk.getSkill('Fletching')?.experience || 0;
-        const startTick = this.sdk.getState()?.tick || 0;
         const msgBaseline = this.helpers.getMessageTick();
 
         // Use knife on logs to open fletching dialog
@@ -2066,6 +2084,7 @@ export class BotActions {
         // Handle product selection and crafting
         const MAX_ATTEMPTS = 30;
         let buttonClicked = false;
+        let chosenLabel: string | undefined;
 
         for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
             const state = this.sdk.getState();
@@ -2076,12 +2095,11 @@ export class BotActions {
             // Check if XP was gained (success!)
             const currentXp = state.skills.find(s => s.name === 'Fletching')?.experience || 0;
             if (currentXp > fletchingBefore) {
-                const craftedProduct = this.sdk.findInventoryItem(/shortbow|longbow|arrow shaft|stock/i);
                 return {
                     success: true,
-                    message: 'Fletched logs successfully',
+                    message: chosenLabel ? `Fletched ${chosenLabel}` : 'Fletched logs successfully',
                     xpGained: currentXp - fletchingBefore,
-                    product: craftedProduct || undefined
+                    product: this.findFletchedProduct(chosenLabel) || undefined
                 };
             }
 
@@ -2106,105 +2124,35 @@ export class BotActions {
                 continue;
             }
 
-            // Handle dialog - use allComponents to find the right button
+            // Handle the skill dialog. Its buttons run Make X / Make 10 /
+            // Make 5 / <product> per product, so the product's own button is
+            // the only one carrying a name — match on that rather than guessing
+            // an index from the log tier.
             if (state.dialog.isOpen) {
-                if (!buttonClicked && product && state.dialog.allComponents) {
-                    // Find the button that matches our product by looking at allComponents text
-                    const productLower = product.toLowerCase();
-
-                    // Build a mapping of product text to button index
-                    // allComponents contains both text labels and "Ok" buttons
-                    // We need to find which "Ok" button corresponds to our product
-
-                    // Look for a component whose text matches the product
-                    const matchingComponents = state.dialog.allComponents.filter(c => {
-                        const text = c.text.toLowerCase();
-                        // Match patterns like "shortbow", "longbow", "arrow shaft"
-                        if (productLower.includes('short') && text.includes('shortbow')) return true;
-                        if (productLower.includes('long') && text.includes('longbow')) return true;
-                        if (productLower.includes('arrow') && text.includes('arrow')) return true;
-                        if (productLower.includes('shaft') && text.includes('shaft')) return true;
-                        if (productLower.includes('stock') && text.includes('stock')) return true;
-                        // Generic match
-                        return text.includes(productLower);
-                    });
-
-                    if (matchingComponents.length > 0) {
-                        // Found a matching text component - now find the associated Ok button
-                        // The Ok buttons in dialog.options should correspond to the products
-                        // Try to find the index by matching component IDs or order
-
-                        // Get all Ok buttons from options
-                        const okButtons = state.dialog.options.filter(o =>
-                            o.text.toLowerCase() === 'ok'
-                        );
-
-                        if (okButtons.length > 0) {
-                            // Try to determine which Ok button to click based on product type
-                            // Button order depends on log type:
-                            // - Regular logs: [Arrow shafts, Shortbow, Longbow] - 3 main products
-                            // - Oak/higher logs: [Shortbow, Longbow] - 2 main products (no arrow shafts option)
-                            let okIndex = 0; // Default to first
-
-                            if (productLower.includes('short')) {
-                                if (isOakOrHigherLogs) {
-                                    // Oak/higher logs: Shortbow is first (index 0)
-                                    okIndex = 0;
-                                } else {
-                                    // Regular logs: Shortbow is second (index 1, after arrow shafts)
-                                    okIndex = Math.min(1, okButtons.length - 1);
-                                }
-                            } else if (productLower.includes('long')) {
-                                if (isOakOrHigherLogs) {
-                                    // Oak/higher logs: Longbow is second (index 1)
-                                    okIndex = Math.min(1, okButtons.length - 1);
-                                } else {
-                                    // Regular logs: Longbow is third (index 2)
-                                    okIndex = Math.min(2, okButtons.length - 1);
-                                }
-                            } else if (productLower.includes('stock')) {
-                                okIndex = Math.min(3, okButtons.length - 1);
-                            }
-                            // arrow/shaft stays at 0
-
-                            const targetButton = okButtons[okIndex];
-                            if (targetButton) {
-                                await this.sdk.sendClickDialog(targetButton.index);
-                                buttonClicked = true;
-                                await this.sdk.waitForTicks(1);
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                // Fallback: use index-based approach if we couldn't match by text
                 if (!buttonClicked) {
-                    // Determine fallback index based on product keyword and log type
-                    let targetButtonIndex = 1; // Default: first option
-                    if (product) {
-                        const productLower = product.toLowerCase();
-                        if (productLower.includes('short')) {
-                            // Oak/higher: shortbow is button 1; Regular: button 2
-                            targetButtonIndex = isOakOrHigherLogs ? 1 : 2;
-                        } else if (productLower.includes('long')) {
-                            // Oak/higher: longbow is button 2; Regular: button 3
-                            targetButtonIndex = isOakOrHigherLogs ? 2 : 3;
-                        } else if (productLower.includes('stock')) {
-                            targetButtonIndex = 4;
-                        }
-                        // arrow/shaft stays at 1
-                    }
+                    const target = resolveSkillDialogProduct(state.dialog.options, product);
 
-                    if (state.dialog.options.length >= targetButtonIndex) {
-                        await this.sdk.sendClickDialog(targetButtonIndex);
+                    if (target) {
+                        await this.sdk.sendClickDialog(target.index);
+                        chosenLabel = target.text;
                         buttonClicked = true;
                         await this.sdk.waitForTicks(1);
                         continue;
                     }
+
+                    if (product) {
+                        const available = skillDialogProductLabels(state.dialog.options);
+                        if (available.length > 0) {
+                            return {
+                                success: false,
+                                message: `No fletching product matched "${product}". Available: ${available.map(l => `"${l}"`).join(', ')}`
+                            };
+                        }
+                    }
                 }
 
-                // If we already clicked or don't have enough options, click continue/first
+                // Already clicked, or this is a continue-style dialog with no
+                // product buttons (level-up, "you need level N").
                 if (state.dialog.options.length > 0 && state.dialog.options[0]) {
                     await this.sdk.sendClickDialog(state.dialog.options[0].index);
                 } else {
@@ -2230,16 +2178,36 @@ export class BotActions {
         // Final XP check
         const finalXp = this.sdk.getSkill('Fletching')?.experience || 0;
         if (finalXp > fletchingBefore) {
-            const craftedProduct = this.sdk.findInventoryItem(/shortbow|longbow|arrow shaft|stock/i);
             return {
                 success: true,
-                message: 'Fletched logs successfully',
+                message: chosenLabel ? `Fletched ${chosenLabel}` : 'Fletched logs successfully',
                 xpGained: finalXp - fletchingBefore,
-                product: craftedProduct || undefined
+                product: this.findFletchedProduct(chosenLabel) || undefined
             };
         }
 
         return { success: false, message: 'Fletching timed out' };
+    }
+
+    /**
+     * Locate the item just fletched. The dialog label ("15 Arrow Shafts",
+     * "Oak Short Bow") names the product but not as the item is named in the
+     * inventory, so match on its significant words before falling back to the
+     * generic fletching-output pattern.
+     */
+    private findFletchedProduct(label?: string): InventoryItem | null {
+        if (label) {
+            const words = label.toLowerCase().match(/[a-z]+/g) ?? [];
+            const significant = words.filter(w => w.length > 2);
+            if (significant.length > 0) {
+                const byLabel = this.sdk.getInventory().find(item => {
+                    const name = item.name.toLowerCase().replace(/\s+/g, '');
+                    return significant.every(word => name.includes(word.replace(/s$/, '')));
+                });
+                if (byLabel) return byLabel;
+            }
+        }
+        return this.sdk.findInventoryItem(/shortbow|longbow|arrow shaft|stock/i);
     }
 
     /** Craft leather into armour using needle and thread. */

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -1016,9 +1016,36 @@ export class BotSDK {
         return this.sendAction({ type: 'dropItem', slot, reason: 'SDK' });
     }
 
-    /** Use one inventory item on another. */
+    /**
+     * Use one inventory item on another.
+     *
+     * Rejected up front while a shop or bank modal is open: those replace the
+     * inventory tab, so the server drops the packet as "component not visible"
+     * and sends no message at all. Close the modal first — `bot.closeShop()`,
+     * `bot.closeInterface()`, or `sendCloseModal()`.
+     */
     async sendUseItemOnItem(sourceSlot: number, targetSlot: number): Promise<ActionResult> {
+        const blocker = this.describeInventoryBlocker();
+        if (blocker) {
+            return { success: false, message: blocker, reason: 'modal_open' };
+        }
         return this.sendAction({ type: 'useItemOnItem', sourceSlot, targetSlot, reason: 'SDK' });
+    }
+
+    /**
+     * Name the open modal that hides the inventory tab from the server, if any.
+     * Returns null when inventory packets can be expected to land.
+     */
+    private describeInventoryBlocker(): string | null {
+        const state = this.getState();
+        if (!state) return null;
+        if (state.shop.isOpen) {
+            return 'Shop interface is open, which replaces the inventory tab - the server will silently drop this. Close it first (bot.closeShop() / sdk.sendCloseShop()).';
+        }
+        if (state.bank.isOpen) {
+            return 'Bank interface is open, which replaces the inventory tab - the server will silently drop this. Close it first (bot.closeInterface() / sdk.sendCloseModal()).';
+        }
+        return null;
     }
 
     /** Use an inventory item on a location. */

--- a/sdk/test/action-quantity.test.ts
+++ b/sdk/test/action-quantity.test.ts
@@ -4,11 +4,13 @@ import {
     countItems,
     nextShopStep,
     resolveInterfaceOption,
+    resolveSkillDialogProduct,
+    skillDialogProductLabels,
     validateActionQuantity,
     MAX_ACTION_QUANTITY,
     MAX_SHOP_ACTION_QUANTITY,
 } from '../action-quantity';
-import type { InterfaceOption, InventoryItem } from '../types';
+import type { DialogOption, InterfaceOption, InventoryItem } from '../types';
 
 function option(index: number, text: string, componentId: number): InterfaceOption {
     return { index, text, componentId };
@@ -53,6 +55,77 @@ describe('resolveInterfaceOption', () => {
         const sticky = /leather/gi;
         expect(resolveInterfaceOption(options, sticky)?.text).toBe('Leather body');
         expect(resolveInterfaceOption(options, sticky)?.text).toBe('Leather body');
+    });
+});
+
+// skill_multi3 as the fletching dialog actually publishes it: four buttons per
+// product, and only the make-1 button carries the product's name. The labels
+// arrive whitespace-normalised (the raw text is "\n\n\n\n15 Arrow Shafts").
+const FLETCH_REGULAR_LOGS: DialogOption[] = [
+    { index: 1, text: 'Make X' },
+    { index: 2, text: 'Make 10' },
+    { index: 3, text: 'Make 5' },
+    { index: 4, text: '15 Arrow Shafts' },
+    { index: 5, text: 'Make X' },
+    { index: 6, text: 'Make 10' },
+    { index: 7, text: 'Make 5' },
+    { index: 8, text: 'Short Bow' },
+    { index: 9, text: 'Make X' },
+    { index: 10, text: 'Make 10' },
+    { index: 11, text: 'Make 5' },
+    { index: 12, text: 'Long Bow' },
+];
+
+// skill_multi2, used for oak and above: no arrow shafts, and the labels are
+// prefixed with the log tier.
+const FLETCH_OAK_LOGS: DialogOption[] = [
+    { index: 1, text: 'Make X' },
+    { index: 2, text: 'Make 10' },
+    { index: 3, text: 'Make 5' },
+    { index: 4, text: 'Oak Short Bow' },
+    { index: 5, text: 'Make X' },
+    { index: 6, text: 'Make 10' },
+    { index: 7, text: 'Make 5' },
+    { index: 8, text: 'Oak Long Bow' },
+];
+
+describe('resolveSkillDialogProduct', () => {
+    test('picks the product button, not the option at the product\'s ordinal', () => {
+        // Arrow shafts are the first product but the *fourth* button; clicking
+        // option 1 opens the Make X count prompt and the script hangs.
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS, 'arrow shaft')?.index).toBe(4);
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS, 'short')?.index).toBe(8);
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS, 'long')?.index).toBe(12);
+    });
+
+    test('matches run-together product names against spaced labels', () => {
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS, 'shortbow')?.index).toBe(8);
+        expect(resolveSkillDialogProduct(FLETCH_OAK_LOGS, 'longbow')?.index).toBe(8);
+    });
+
+    test('matches every word in any order', () => {
+        expect(resolveSkillDialogProduct(FLETCH_OAK_LOGS, 'oak short')?.text).toBe('Oak Short Bow');
+        expect(resolveSkillDialogProduct(FLETCH_OAK_LOGS, 'oak long')?.text).toBe('Oak Long Bow');
+    });
+
+    test('defaults to the first product rather than the first button', () => {
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS)?.index).toBe(4);
+        expect(resolveSkillDialogProduct(FLETCH_OAK_LOGS)?.index).toBe(4);
+    });
+
+    test('returns null instead of fletching the wrong product', () => {
+        // 'stock' only exists on crossbow dialogs; silently making a longbow
+        // here is worse than reporting no match.
+        expect(resolveSkillDialogProduct(FLETCH_REGULAR_LOGS, 'stock')).toBeNull();
+        expect(resolveSkillDialogProduct([], 'arrow shaft')).toBeNull();
+    });
+
+    test('lists the products it can offer, for the no-match message', () => {
+        expect(skillDialogProductLabels(FLETCH_REGULAR_LOGS)).toEqual([
+            '15 Arrow Shafts',
+            'Short Bow',
+            'Long Bow',
+        ]);
     });
 });
 

--- a/server/webclient/src/bot/ClientInteraction.test.ts
+++ b/server/webclient/src/bot/ClientInteraction.test.ts
@@ -71,6 +71,15 @@ mock.module('#/client/MobileKeyboard.js', () => ({
 };
 
 const { Client } = await import('../client/Client.js');
+const { default: IfType } = await import('#/config/IfType.js');
+
+const BUTTON_OK = 1;
+const BUTTON_CLOSE = 3;
+
+/** Install a component in the shared IfType registry the client reads from. */
+function defineComponent(id: number, com: Record<string, unknown>): void {
+    IfType.list[id] = { id, ...com } as never;
+}
 
 describe('ranged spell dispatch', () => {
     test('dispatches a combat spell when adjacency routing fails', () => {
@@ -116,5 +125,70 @@ describe('ranged spell dispatch', () => {
         expect(result).toEqual({ success: true, routed: false });
         expect(opcodes).toEqual([91]); // ClientProt.OPOBJT
         expect(payload).toEqual([3205, 3206, 995, 1151]);
+    });
+});
+
+describe('clickComponent', () => {
+    test('closes the modal for a close-type button instead of sending IF_BUTTON', () => {
+        // shop_template:com_77 ("Close Window"). The server has no if_button
+        // trigger for it and answers "No trigger for [if_button,...]", leaving
+        // the modal open and silently swallowing every following action.
+        defineComponent(3902, { buttonType: BUTTON_CLOSE, text: 'Close Window' });
+
+        const opcodes: number[] = [];
+        let closed = 0;
+        const client = {
+            ingame: true,
+            out: { p2: () => {} },
+            writePacketOpcode: (opcode: number) => opcodes.push(opcode),
+            closeModal: () => { closed++; }
+        };
+
+        expect(Client.prototype.clickComponent.call(client, 3902)).toBe(true);
+        expect(closed).toBe(1);
+        expect(opcodes).toEqual([]);
+    });
+
+    test('still sends IF_BUTTON for ordinary buttons', () => {
+        defineComponent(3903, { buttonType: BUTTON_OK, buttonText: 'Buy 10' });
+
+        const opcodes: number[] = [];
+        const payload: number[] = [];
+        const client = {
+            ingame: true,
+            out: { p2: (value: number) => payload.push(value) },
+            writePacketOpcode: (opcode: number) => opcodes.push(opcode),
+            closeModal: () => { throw new Error('should not close the modal'); }
+        };
+
+        expect(Client.prototype.clickComponent.call(client, 3903)).toBe(true);
+        expect(opcodes).toEqual([9]); // ClientProt.IF_BUTTON
+        expect(payload).toEqual([3903]);
+    });
+});
+
+describe('getDialogOptions', () => {
+    test('flattens the layout newlines skill dialogs pad product labels with', () => {
+        // skill_multi3, as fletching opens it: Make X / Make 10 / Make 5 /
+        // <product>, and only the make-1 button carries a name.
+        defineComponent(9000, { children: [9001, 9002, 9003, 9004] });
+        defineComponent(9001, { buttonType: BUTTON_OK, buttonText: 'Make X', text: '' });
+        defineComponent(9002, { buttonType: BUTTON_OK, buttonText: 'Make 10', text: '' });
+        defineComponent(9003, { buttonType: BUTTON_OK, buttonText: 'Make 5', text: '' });
+        defineComponent(9004, { buttonType: BUTTON_OK, buttonText: 'Make 1', text: '\n\n\n\n15 Arrow Shafts' });
+
+        const options = Client.prototype.getDialogOptions.call({ chatModalId: 9000 });
+
+        expect(options.map(o => o.text)).toEqual(['Make X', 'Make 10', 'Make 5', '15 Arrow Shafts']);
+        expect(options[3].index).toBe(4);
+    });
+
+    test('falls back to the button text when the label is only padding', () => {
+        defineComponent(9100, { children: [9101] });
+        defineComponent(9101, { buttonType: BUTTON_OK, buttonText: 'Make 5', text: '\n\n\n\n' });
+
+        const options = Client.prototype.getDialogOptions.call({ chatModalId: 9100 });
+
+        expect(options.map(o => o.text)).toEqual(['Make 5']);
     });
 });

--- a/server/webclient/src/client/Client.ts
+++ b/server/webclient/src/client/Client.ts
@@ -93,6 +93,22 @@ const SCROLLBAR_GRIP_FOREGROUND = 0x4d4233;
 const SCROLLBAR_GRIP_HIGHLIGHT = 0x766654;
 const SCROLLBAR_GRIP_LOWLIGHT = 0x332d25;
 
+/**
+ * Flatten a component's display text into a single readable line.
+ *
+ * Skill dialogs position their product labels with embedded newlines
+ * (`if_settext(skill_multi3:make1_a, "\n\n\n\n15 Arrow Shafts")`) and sprinkle
+ * `@col@` codes through chat text. Both are layout, not content, and both
+ * defeat naive string matching against an option label.
+ */
+export function normaliseComponentText(raw: string | null | undefined): string {
+    if (!raw) return '';
+    return raw
+        .replace(/@\w{3}@/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
 /** Result of {@link Client.say} — reports truncation/censorship the wire hides. */
 export interface SayOutcome {
     ok: boolean;
@@ -2303,7 +2319,10 @@ export class Client extends GameShell {
             if (!com) return;
 
             if ((com.buttonType === ButtonType.BUTTON_OK || com.buttonType === ButtonType.BUTTON_CONTINUE) && com.buttonText) {
-                const displayText = com.text || com.buttonText;
+                // com.text carries the product label on skill dialogs but is
+                // pure layout padding on the Make X/10/5 siblings, so fall back
+                // to buttonText once the whitespace is stripped.
+                const displayText = normaliseComponentText(com.text) || normaliseComponentText(com.buttonText);
                 options.push({
                     index: options.length + 1,
                     text: displayText,
@@ -2533,7 +2552,7 @@ export class Client extends GameShell {
             if (isClickable && (com.buttonText || com.text)) {
                 options.push({
                     index: options.length + 1,
-                    text: com.buttonText || com.text || `Option ${options.length + 1}`,
+                    text: normaliseComponentText(com.buttonText) || normaliseComponentText(com.text) || `Option ${options.length + 1}`,
                     componentId: comId
                 });
             }
@@ -2577,6 +2596,16 @@ export class Client extends GameShell {
     clickComponent(componentId: number): boolean {
         if (!this.ingame || !this.out) {
             return false;
+        }
+
+        // buttontype=close components (every "Close Window" X) are handled
+        // locally by the real client - the server registers no if_button
+        // trigger for them and answers IF_BUTTON with "No trigger for ...",
+        // leaving the modal open. Route them to closeModal() like a real click.
+        const com = IfType.list[componentId];
+        if (com && com.buttonType === ButtonType.BUTTON_CLOSE) {
+            this.closeModal();
+            return true;
         }
 
         this.writePacketOpcode(ClientProt.IF_BUTTON);


### PR DESCRIPTION
Three related bot-facing bugs, each traced to a root cause in the client/engine rather than patched over in the porcelain.

## Close buttons were sent to a server that has no trigger for them

`shop_template:com_77` ("Close Window") is `buttontype=close` — the real client handles close-type buttons locally and never puts them on the wire. `Client.clickComponent()` wrote an `IF_BUTTON` packet for any component id, so the server answered `No trigger for [if_button,shop_template:com_77]` and the modal stayed open.

Close-type components now route to `closeModal()`, matching a real click.

## An open modal silently ate the next action

A shop or bank replaces the inventory tab, so `Player.isComponentVisible()` rejects inventory packets sent underneath it — returning `false` with no game message at all. `sendUseItemOnItem(knife, logs)` genuinely appeared to do nothing.

It now fails up front with `reason: 'modal_open'` and names the method to call.

`bot.closeInterface()` / `closeShop()` / `closeBank()` already existed and were in `sdk/API.md`; they were missing from the CLAUDE.md quick reference, which is where you'd look. Added, along with `sendCloseModal()` / `sendCloseShop()`.

## fletchLogs never once took its intended path

It searched `dialog.options` for buttons reading `"Ok"`. `skill_multi3` has none — its twelve buttons run `Make X` / `Make 10` / `Make 5` / `<product>` per product. So that branch never fired and every call fell through to an index guess:

- `'arrow shaft'` clicked option 1 = **Make X**, opening the count prompt and hanging
- `'short'` on regular logs clicked option 2 = **Make 10 arrow shafts** — wrong product entirely

Product labels also arrive padded with layout newlines from `if_settext` (`"\n\n\n\n15 Arrow Shafts"`), defeating string matching.

Fixes:

- **Labels are flattened at the client** (`normaliseComponentText`) — newlines collapsed, `@col@` codes stripped, falling back to `buttonText` when a label is only padding (which is what makes the quantity buttons readable as `Make 5`).
- **`resolveSkillDialogProduct()`** replaces the log-tier index guessing. Only the make-1 button carries a name, so the named options *are* the products in order. Matches every word in any order (`'oak short'` → "Oak Short Bow"), then punctuation-insensitively (`'shortbow'` → same).
- **No match reports the available labels** instead of fletching something else.
- **Pre-flight guard** so the `dialog.isOpen || interface?.isOpen` wait can't be satisfied instantly by a shop modal that was already up.

## Testing

`bun run check` — typecheck, webclient typecheck, 81 tests, all passing. Verified in a clean worktree so the commit stands on its own.

New coverage: 6 unit tests for the resolver against the real 12-option `skill_multi3` shape (regular logs and the oak `skill_multi2` variant), and 4 for close-button routing and label flattening.

## Notes

- `getInterfaceOptions()` still excludes close buttons, so they don't appear in `interface.options` — `bot.closeInterface()` is the intended path, and the routing fix covers reaching one by id from `debugInfo`.
- `fletchLogs` still makes one batch per call. The Make 10 / Make X buttons are now cleanly addressable if a quantity parameter is wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)