### PR TITLE
fix(sdk): route to doors and gates with the wall reach rule

### DIFF
--- a/sdk/actions.ts
+++ b/sdk/actions.ts
@@ -4,7 +4,7 @@
 
 import { BotSDK } from './index';
 import { ActionHelpers } from './actions-helpers';
-import { findDoorsAlongPath } from './pathfinding';
+import { findDoorsAlongPath, isTileWalkable } from './pathfinding';
 import type {
     ActionResult,
     SkillState,
@@ -893,8 +893,15 @@ export class BotActions {
                 await this.sdk.waitForTicks(1);
                 path = await this.sdk.sendFindPath(x, z, 500);
                 if (!path.success || !path.waypoints?.length) {
-                    console.error(`[walkTo] PATHFINDING FAILED: ${path.error ?? 'no waypoints'} - from (${pos.x}, ${pos.z}) to (${x}, ${z})`);
-                    return { success: false, message: `No path to (${x}, ${z}) from (${pos.x}, ${pos.z}): ${path.error ?? 'no waypoints'}` };
+                    // "no waypoints" reads as broken collision data, but the usual
+                    // cause is a destination that is simply blocked — a wall, or a
+                    // tile a loc stands on. Say which, so callers pick a neighbour
+                    // tile instead of chasing a phantom pathfinder bug.
+                    const level = this.sdk.getState()?.player?.level ?? 0;
+                    const reason = path.error
+                        ?? (isTileWalkable(level, x, z) ? 'no waypoints' : 'destination tile is blocked');
+                    console.error(`[walkTo] PATHFINDING FAILED: ${reason} - from (${pos.x}, ${pos.z}) to (${x}, ${z})`);
+                    return { success: false, message: `No path to (${x}, ${z}) from (${pos.x}, ${pos.z}): ${reason}` };
                 }
             }
 

--- a/server/webclient/src/bot/ClientInteraction.test.ts
+++ b/server/webclient/src/bot/ClientInteraction.test.ts
@@ -71,6 +71,7 @@ mock.module('#/client/MobileKeyboard.js', () => ({
 };
 
 const { Client } = await import('../client/Client.js');
+const { default: LocType } = await import('#/config/LocType.js');
 const { default: IfType } = await import('#/config/IfType.js');
 
 const BUTTON_OK = 1;
@@ -190,5 +191,117 @@ describe('getDialogOptions', () => {
         const options = Client.prototype.getDialogOptions.call({ chatModalId: 9100 });
 
         expect(options.map(o => o.text)).toEqual(['Make 5']);
+    });
+});
+
+describe('loc routing', () => {
+    type MoveArgs = {
+        destX: number; destZ: number;
+        locWidth: number; locLength: number;
+        locAngle: number; locShape: number;
+        forceapproach: number;
+    };
+
+    /** Back a stub with the real prototype so routeToLoc's private helpers resolve. */
+    function asClient(stub: Record<string, unknown>): { routeToLoc(x: number, z: number, locId: number): boolean } {
+        return Object.assign(Object.create(Client.prototype), stub);
+    }
+
+    /** Register a loc definition LocType.list() will hand back untouched. */
+    function defineLoc(id: number, props: Partial<{ width: number; length: number; forceapproach: number }>): void {
+        const loc = Object.assign(Object.create(LocType.prototype), {
+            id, width: 1, length: 1, forceapproach: 0, ...props
+        });
+        LocType.recent = [loc];
+        LocType.idx = new Int32Array(1) as never;
+        LocType.dat = {} as never;
+    }
+
+    /**
+     * Route to a loc sitting on one tile, reporting the args tryMove received.
+     * `typecode2` packs shape in the low 5 bits and angle at bit 6, as the scene does.
+     */
+    function route(locId: number, shape: number, angle: number): MoveArgs {
+        let args: MoveArgs | null = null;
+        const client = asClient({
+            localPlayer: { routeX: [10], routeZ: [10] },
+            minusedlevel: 0,
+            world: {
+                wallType: () => (shape <= 3 || shape === 9 ? (locId << 14) : 0),
+                decorType: () => (shape >= 4 && shape <= 8 ? (locId << 14) : 0),
+                sceneType: () => (shape >= 10 && shape <= 21 ? (locId << 14) : 0),
+                gdType: () => (shape === 22 ? (locId << 14) : 0),
+                typeCode2: () => shape | (angle << 6)
+            },
+            tryMove: (
+                _srcX: number, _srcZ: number, destX: number, destZ: number, _tryNearest: boolean,
+                locWidth: number, locLength: number, locAngle: number, locShape: number,
+                forceapproach: number
+            ) => {
+                args = { destX, destZ, locWidth, locLength, locAngle, locShape, forceapproach };
+                return true;
+            }
+        });
+
+        client.routeToLoc(20, 30, locId);
+        expect(args).not.toBeNull();
+        return args!;
+    }
+
+    test('routes to a gate with the wall reach rule, not the rectangle one', () => {
+        // Lumbridge chicken coop gate: shape 0 (WALL_STRAIGHT), angle 2 (EAST).
+        // The rectangle rule accepts the tile west of the gate, which the server
+        // rejects with "I can't reach that!" — the wall rule does not.
+        defineLoc(1553, { width: 1, length: 1 });
+
+        expect(route(1553, 0, 2)).toEqual({
+            destX: 20, destZ: 30,
+            locWidth: 0, locLength: 0,
+            locAngle: 2, locShape: 1, // shape + 1, as tryMove expects
+            forceapproach: 0
+        });
+    });
+
+    test('routes to a wall decoration with the decor reach rule', () => {
+        defineLoc(1234, { width: 1, length: 1 });
+
+        expect(route(1234, 6, 3)).toMatchObject({ locWidth: 0, locLength: 0, locAngle: 3, locShape: 7 });
+    });
+
+    test('keeps the rotated rectangle footprint for centrepieces', () => {
+        // A 3x1 loc rotated north swaps its footprint, and forceapproach rotates with it.
+        defineLoc(4321, { width: 3, length: 1, forceapproach: 1 });
+
+        expect(route(4321, 10, 1)).toEqual({
+            destX: 20, destZ: 30,
+            locWidth: 1, locLength: 3,
+            locAngle: 0, locShape: 0,
+            forceapproach: 2
+        });
+    });
+
+    test('falls back to the rectangle footprint when the tile holds no such loc', () => {
+        defineLoc(999, { width: 2, length: 2 });
+
+        let args: MoveArgs | null = null;
+        const client = asClient({
+            localPlayer: { routeX: [1], routeZ: [1] },
+            minusedlevel: 0,
+            world: {
+                wallType: () => 0, decorType: () => 0, sceneType: () => 0, gdType: () => 0,
+                typeCode2: () => -1
+            },
+            tryMove: (
+                _sx: number, _sz: number, destX: number, destZ: number, _tn: boolean,
+                locWidth: number, locLength: number, locAngle: number, locShape: number, forceapproach: number
+            ) => {
+                args = { destX, destZ, locWidth, locLength, locAngle, locShape, forceapproach };
+                return true;
+            }
+        });
+
+        client.routeToLoc(5, 6, 999);
+
+        expect(args).toMatchObject({ locWidth: 2, locLength: 2, locAngle: 0, locShape: 0 });
     });
 });

--- a/server/webclient/src/client/Client.ts
+++ b/server/webclient/src/client/Client.ts
@@ -2040,11 +2040,7 @@ export class Client extends GameShell {
         if (!loc) {
             return { success: false, reason: 'target_not_found' };
         }
-        const routed = this.tryMove(
-            this.localPlayer.routeX[0], this.localPlayer.routeZ[0],
-            destSceneX, destSceneZ,
-            false, loc.width, loc.length, 0, 0, 0, 2
-        );
+        const routed = this.routeToLoc(destSceneX, destSceneZ, locId);
         if (!routed) {
             return { success: false, reason: 'cant_reach' };
         }
@@ -2216,6 +2212,85 @@ export class Client extends GameShell {
     }
 
     /**
+     * Find the scene shape/angle of a loc sitting at the given scene tile.
+     *
+     * The bot API only knows a loc's id and world position, but reachability
+     * depends on its shape: a wall (door, gate) is approached across the tile
+     * edge it occupies, not around a rectangular footprint. Mirrors how
+     * interactWithLoc() derives shape/angle from the typecode on a mouse click.
+     * Returns null when no loc with this id is on the tile (stale target).
+     */
+    private locSceneInfo(sceneX: number, sceneZ: number, locId: number): { shape: number; angle: number } | null {
+        if (!this.world) {
+            return null;
+        }
+        const level = this.minusedlevel;
+        const typecodes: number[] = [
+            this.world.wallType(level, sceneX, sceneZ),
+            this.world.decorType(level, sceneZ, sceneX), // decorType takes (level, z, x)
+            this.world.sceneType(level, sceneX, sceneZ),
+            this.world.gdType(level, sceneX, sceneZ)
+        ];
+
+        for (const typecode of typecodes) {
+            if (typecode === 0 || ((typecode >> 14) & 0x7fff) !== locId) {
+                continue;
+            }
+            const info: number = this.world.typeCode2(level, sceneX, sceneZ, typecode);
+            if (info === -1) {
+                continue;
+            }
+            return { shape: info & 0x1f, angle: (info >> 6) & 0x3 };
+        }
+        return null;
+    }
+
+    /**
+     * Route the player to a loc the way the mouse-click path does (interactWithLoc),
+     * picking the reach rule that matches the loc's shape.
+     *
+     * Walls and wall decorations get the wall reach test; everything else gets the
+     * rotated rectangle footprint plus forceapproach. Getting this wrong parks the
+     * player on a tile the server rejects, so the OPLOC that follows draws
+     * "I can't reach that!" — which is what happened to every door and gate while
+     * this always used the rectangle rule.
+     */
+    private routeToLoc(sceneX: number, sceneZ: number, locId: number): boolean {
+        if (!this.localPlayer) {
+            return false;
+        }
+
+        const srcX = this.localPlayer.routeX[0];
+        const srcZ = this.localPlayer.routeZ[0];
+        const info = this.locSceneInfo(sceneX, sceneZ, locId);
+        const shape = info?.shape ?? LocShape.CENTREPIECE_STRAIGHT;
+        const angle = info?.angle ?? LocAngle.WEST;
+
+        if (shape === LocShape.CENTREPIECE_STRAIGHT || shape === LocShape.CENTREPIECE_DIAGONAL || shape === LocShape.GROUND_DECOR) {
+            const loc: LocType = LocType.list(locId);
+
+            let width: number;
+            let height: number;
+            if (angle === LocAngle.WEST || angle === LocAngle.EAST) {
+                width = loc.width;
+                height = loc.length;
+            } else {
+                width = loc.length;
+                height = loc.width;
+            }
+
+            let forceapproach: number = loc.forceapproach;
+            if (angle !== 0) {
+                forceapproach = ((forceapproach << angle) & 0xf) + (forceapproach >> (4 - angle));
+            }
+
+            return this.tryMove(srcX, srcZ, sceneX, sceneZ, false, width, height, 0, 0, forceapproach, 2);
+        }
+
+        return this.tryMove(srcX, srcZ, sceneX, sceneZ, false, 0, 0, angle, shape + 1, 0, 2);
+    }
+
+    /**
      * Interact with a location/object in the world (doors, trees, etc.)
      */
     interactLoc(worldX: number, worldZ: number, locId: number, optionIndex: number): ClientActionResult {
@@ -2243,7 +2318,7 @@ export class Client extends GameShell {
         if (!loc) {
             return { success: false, reason: 'target_not_found' };
         }
-        const routed = this.tryMove(this.localPlayer.routeX[0], this.localPlayer.routeZ[0], destSceneX, destSceneZ, false, loc.width, loc.length, 0, 0, 0, 2);
+        const routed = this.routeToLoc(destSceneX, destSceneZ, locId);
         if (!routed) {
             return { success: false, reason: 'cant_reach' };
         }


### PR DESCRIPTION
## The symptom

A bot reported every chicken pen near Lumbridge as sealed: the coop gates at `(3236,3295)`/`(3236,3296)` returned `cant_reach` from every flanking tile, and it concluded feathers could only be bought in Port Sarim.

## The cause

Those gates are `shape 0` (`WALL_STRAIGHT`), `angle 2` (`EAST`) — confirmed in `sdk/collision-data.json`. For a wall the server (`ReachStrategy.reachWall1`) accepts only:

- `(3236,3295)` — the gate's own tile
- `(3237,3295)` — the far side
- `(3236,3294)` / `(3236,3296)` — north/south with the perpendicular edge open

`(3235,3295)`, the tile directly west where a bot arriving from Lumbridge stops, is **not** legal.

`Client.interactLoc()` and `useItemOnLoc()` called `tryMove()` with the loc's rectangular footprint and a hardcoded shape/angle of `0`. With `locShape === 0`, `tryMove` skips its `testWall`/`testWDecor` branches and falls through to `testLoc` — the rectangle approach test, which accepts any open side. So the client walked the player to `(3235,3295)`, declared "arrived", and fired `OPLOC` from a tile the server rejects.

Introduced in d3c390330 (2026-05-22), which taught these methods to route at all for 274's client-routefinder mode. It fixed trees and rocks; wall shapes were never covered.

## The fix

Resolve the loc's shape and angle from the scene typecode and branch the way the real mouse-click path does (`interactWithLoc`, `Client.ts:7802`). This also restores the rotated footprint and `forceapproach` that centrepieces were silently losing. Falls back to the old rectangle footprint when the tile holds no matching loc.

Also names the usual cause when `walkTo` finds no path — a blocked destination tile reported as "no waypoints" reads as broken collision data. That misdiagnosis already happened: `(3238,3408) -> (3238,3409)` failed because `isTileWalkable(0,3238,3409)` is `false`, not because the pathfinder was broken.

## Verification

- 4 new regression tests pin the reach rule per shape (wall, wall decor, rotated centrepiece, missing-loc fallback); the wall case fails against the old code.
- `bun run check` passes: 95 tests, typecheck clean.
- Webclient bundle builds.

Not yet verified in-game against the live coop gate — worth a bot run right after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)