### PR TITLE
Restore global fetch after ClientInteraction tests so lite oracle tests stop silently skipping

### DIFF
--- a/server/webclient/src/bot/ClientInteraction.test.ts
+++ b/server/webclient/src/bot/ClientInteraction.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterAll, describe, expect, mock, test } from 'bun:test';
 
 mock.module('#3rdparty/tinymidipcm.js', () => ({
     stopMidi() {},
@@ -37,8 +37,14 @@ mock.module('#/client/MobileKeyboard.js', () => ({
     }
 };
 (globalThis as any).navigator = { userAgent: 'bun-test' };
+// Later test files in the same process (lite/) need the real fetch to reach
+// the game server; leaving this stub installed makes them all skip.
+const realFetch = globalThis.fetch;
 (globalThis as any).fetch = async () => ({
     arrayBuffer: async () => new ArrayBuffer(0)
+});
+afterAll(() => {
+    (globalThis as any).fetch = realFetch;
 });
 (globalThis as any).document = {
     hidden: false,


### PR DESCRIPTION
## Problem

`server/webclient/src/bot/ClientInteraction.test.ts` replaces `globalThis.fetch` with a stub (returning an empty `ArrayBuffer`) so it can exercise client code without a DOM or network — but the stub is never removed.

`bun test` runs every test file in a single process, and the `test` script lists `server/webclient/src/bot` before `server/webclient/src/lite`. So by the time the lite suites run, `loadCache`'s probe of the game server (`GET /crc`) hits the stub instead of real `fetch`, throws, and each suite prints:

```
[skip] https://rs-sdk-demo.fly.dev unreachable
```

and skips its test bodies — even when the demo server is perfectly reachable. The skip message blames the network, so the suite still reports green while the online oracle tests (packet-errors, interfaces, cycles, action-encoding, crc-redeploy, and the collision oracle) never actually run.

Easy to confirm: run any lite test file alone and it passes against the live server; run the full suite and it skips as "unreachable".

## Fix

Capture the real `fetch` before installing the stub and restore it in an `afterAll` hook. File-local behavior is unchanged; only later files in the process are affected.

## Result

Full `bun run test` on my machine goes from 259 pass with 8 hidden skips (1059 `expect()` calls) to 259 pass with 0 skips (1222 `expect()` calls), with the oracle tests genuinely executing against the demo server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
