### PR TITLE
pathfinding: never auto-route through the Al Kharid toll gate

### DIFF
--- a/sdk/pathfinding.ts
+++ b/sdk/pathfinding.ts
@@ -75,6 +75,16 @@ const ONE_WAY_DOORS = new Set<string>([
     '0,3109,3353', // Draynor Manor front door (east tile) — only opens from outside
 ]);
 
+// Pay-gates: doors that open a payment dialog instead of opening on interact.
+// Auto-routing through them strands the bot on the dialog mid-walk (and the
+// 10gp toll dialog's options are 1-based, so naive dialog handlers hang).
+// Keep their walls so walkTo never treats them as passable; scripts that want
+// to cross must interact with the gate deliberately and answer the dialog.
+const PAY_GATES = new Set<string>([
+    '0,3268,3227', // Al Kharid toll gate (north tile)
+    '0,3268,3228', // Al Kharid toll gate (south tile)
+]);
+
 function doorKey(level: number, x: number, z: number): string {
     return `${level},${x},${z}`;
 }
@@ -124,7 +134,7 @@ export function initPathfinding(): void {
 
             // Skip one-way doors — keep their wall collision so the pathfinder
             // won't route through them (entering traps the bot).
-            if (ONE_WAY_DOORS.has(key)) {
+            if (ONE_WAY_DOORS.has(key) || PAY_GATES.has(key)) {
                 skippedOneWay++;
                 continue;
             }


### PR DESCRIPTION
walkTo auto-opens doors along a path. The Al Kharid toll gate is indexed like any other door, so paths that graze the border 'open' it mid-walk, which actually pops the 10gp payment dialog with no dialog handling in scope. The walk stalls at the gate indefinitely.

Observed in practice: five bots wedged simultaneously at the gate; one was pushed into the fence column at (3268,3226) with a ghost dialog the server no longer accepted clicks for, recoverable only by a full relog.

Fix: keep the gate's wall collision (same mechanism as ONE_WAY_DOORS) so the pathfinder routes around it. Scripts that want to cross still can, by interacting with the gate deliberately and answering the dialog (note its options are 1-based).

🤖 Generated with [Claude Code](https://claude.com/claude-code)