### PR TITLE
fix stale CLI messages (create-bot chat status, cli.ts client-launch hint)

### DIFF
--- a/bots/create-bot.ts
+++ b/bots/create-bot.ts
@@ -78,13 +78,13 @@ async function createBot(username?: string, serverOverride?: string, hideChat?: 
         console.log(`Server set to: ${serverOverride}`);
     }
 
-    // Public chat is shown by default; disable it with --no-chat / --hide-chat
+    // Public chat defaults to whatever the template sets; --no-chat forces it off.
     if (hideChat) {
         await replaceInFile(envPath, { 'SHOW_CHAT=true': 'SHOW_CHAT=false' });
-        console.log(`Public chat: disabled`);
-    } else {
-        console.log(`Public chat: enabled (default)`);
     }
+    const envText = await readFile(envPath, 'utf-8');
+    const chatOn = /^SHOW_CHAT=true$/m.test(envText);
+    console.log(`Public chat: ${chatOn ? 'enabled' : 'disabled'}`);
 
     console.log(`\n✓ Bot "${botUsername}" created successfully!`);
     console.log(`\nCredentials saved in bots/${botUsername}/bot.env`);

--- a/sdk/cli.ts
+++ b/sdk/cli.ts
@@ -51,7 +51,7 @@ async function connectAndAwaitState(sdk: BotSDK, gatewayUrl: string, username: s
             console.error(`  Nothing is logged into the game as '${username}', so there's no state to report.`);
             console.error(`  This is also what you see after a server restart or when an idle client goes stale.`);
             console.error(`  Fix: open the web client and log in as '${username}', then re-run.`);
-            console.error(`  (Scripts via sdk/runner.ts launch the client for you.)`);
+            console.error(`  (Standalone scripts do not launch a client: sdk/runner.ts sets autoLaunchBrowser: false.)`);
         } else {
             console.error(`Error: No state received for '${username}'`);
             console.error(`  Lost the gateway connection before any state arrived.`);


### PR DESCRIPTION
Two small message fixes that cost us real debugging time:

- `create-bot.ts` prints "Public chat: enabled (default)" even when the template `bot.env` ships `SHOW_CHAT=false`. Now reports the actual value from the created env file.
- `sdk/cli.ts` suggests that runner scripts launch the client ("Scripts via sdk/runner.ts launch the client for you"), but `sdk/runner.ts` deliberately sets `autoLaunchBrowser: false`, so a fresh user waits on a client that never comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)