### PR TITLE
learnings: Al Kharid toll gate hazards; adamantite census

### DIFF
--- a/learnings/mining.md
+++ b/learnings/mining.md
@@ -76,3 +76,22 @@ if (state.inventory.length >= 28) {
     }
 }
 ```
+
+## Adamantite: where it actually is
+
+Server-wide census of adamantite rocks (loc ids 2104/2105/2133/2134):
+
+| Location | Rocks | Notes |
+|----------|-------|-------|
+| Dwarven Mine | 3 | (3035,9764), (3042,9772), (3042,9774). King Scorpions (lvl 32) nearby are aggressive to combat < 65. |
+| Al Kharid mine | 2 | (3298,3317), (3300,3318). Lvl 14 scorpions ignore combat 29+. |
+| Near Seers (surface) | 3 | (2836-2837, 3243-3244) — unverified routing. |
+| Wilderness hobgoblin mine | 7 | PvP risk. |
+| Various dungeons | rest | quest-gated or remote. |
+
+The **Mining Guild has no adamantite** (coal and mithril only). The gold
+cluster at (2731, 3224) south of Catherby is on White Wolf Mountain's slope
+and unroutable from the south ("no waypoints").
+
+Requirements: adamantite needs Mining 70; wielding a pickaxe above your
+Mining level makes mining silently do nothing.

--- a/learnings/walking.md
+++ b/learnings/walking.md
@@ -163,3 +163,24 @@ function isInAlKharid() {
     return player.worldX >= 3267 && player.worldZ < 3220;
 }
 ```
+
+## Al Kharid Toll Gate: a hazard for pathing, not just a fee
+
+Three failure modes observed around the gate at (3268, 3227)-(3268, 3228):
+
+1. **Do not let walkTo route through it.** The pathfinder auto-opens doors on
+   the path; "opening" this gate pops the 10gp payment dialog with no handler
+   in scope and the walk stalls there indefinitely.
+2. **The payment dialog's options are 1-based** ("No thank you" = 1,
+   "Who does my money go to?" = 2, "Yes, ok." = 3). A naive
+   `sendClickDialog(0)` does nothing, forever. Use
+   `bot.navigateDialog([/yes, ok/i])` or click `option.index` from
+   `dialog.options`.
+3. **A bot can get wedged into the fence column** (seen at (3268, 3226)) with
+   a ghost dialog the server no longer accepts clicks for; movement is
+   rejected too. Only known recovery: disconnect the client, wait for the
+   character to fully log out (inGame: false), and log back in.
+
+Cross deliberately: walk to (3266, 3227) / (3270, 3227), interact the gate,
+answer the dialog by text, then verify worldX actually changed sides before
+continuing. Budget 10gp each way.


### PR DESCRIPTION
Field notes from running an 8-bot fleet for a few days:

- The toll gate strands pathfinding bots three distinct ways (auto-open into an unhandled payment dialog; 1-based dialog options defeating `sendClickDialog(0)`; a fence-wedge ghost-dialog state only cured by relogging). Documented the safe crossing procedure.
- Server-wide adamantite census, including two things that cost us hours: the Mining Guild has no adamantite, and the gold cluster south of Catherby is on White Wolf Mountain and unroutable from the south.

🤖 Generated with [Claude Code](https://claude.com/claude-code)