### PR TITLE
fix(engine): freeze hiscore time at achieved level

### DIFF
--- a/server/engine/src/server/login/LoginServer.ts
+++ b/server/engine/src/server/login/LoginServer.ts
@@ -104,15 +104,15 @@ async function updateHiscores(account: { id: number; staffmodlevel: number; bann
         totalLevel += player.baseLevels[i];
     }
 
-    const existing = await db.selectFrom('hiscore_large').select('type').select('value').select('playtime').where('account_id', '=', account.id).where('type', '=', 0).where('profile', '=', profile).executeTakeFirst();
-    if (existing && (existing.value !== totalXp || existing.playtime !== player.playtime)) {
+    const existing = await db.selectFrom('hiscore_large').select('type').select('level').select('value').select('playtime').where('account_id', '=', account.id).where('type', '=', 0).where('profile', '=', profile).executeTakeFirst();
+    if (existing && (existing.value !== totalXp || existing.level !== totalLevel)) {
         await db
             .updateTable('hiscore_large')
             .set({
                 type: 0,
                 level: totalLevel,
                 value: totalXp,
-                playtime: player.playtime,
+                playtime: totalLevel > existing.level ? player.playtime : existing.playtime,
                 date: toDbDate(new Date())
             })
             .where('account_id', '=', account.id)
@@ -142,13 +142,13 @@ async function updateHiscores(account: { id: number; staffmodlevel: number; bann
             const hiscoreType = stat + 1;
 
             // todo: can we upsert in kysely?
-            const existing = await db.selectFrom('hiscore').select('type').select('value').select('playtime').where('account_id', '=', account.id).where('type', '=', hiscoreType).where('profile', '=', profile).executeTakeFirst();
-            if (existing && (existing.value !== player.stats[stat] || existing.playtime !== player.playtime)) {
+            const existing = await db.selectFrom('hiscore').select('type').select('level').select('value').select('playtime').where('account_id', '=', account.id).where('type', '=', hiscoreType).where('profile', '=', profile).executeTakeFirst();
+            if (existing && (existing.value !== player.stats[stat] || existing.level !== player.baseLevels[stat])) {
                 update.push({
                     type: hiscoreType,
                     level: player.baseLevels[stat],
                     value: player.stats[stat],
-                    playtime: player.playtime,
+                    playtime: player.baseLevels[stat] > existing.level ? player.playtime : existing.playtime,
                     date: toDbDate(new Date())
                 });
             } else if (!existing) {


### PR DESCRIPTION
## Root cause

`updateHiscores` treated every lifetime playtime change as a score change and overwrote the stored tie-break time on logout/reconnect. Because equal-level players are ordered by ascending playtime, maxed accounts kept losing rank after reaching max.

## Fix

- ignore playtime-only refreshes
- keep the time a displayed overall/skill level was first reached while still updating same-level XP
- record a new time when the displayed level increases

Existing inflated rows cannot be reconstructed from current score data; this patch prevents further drift.

## Verification

- `bun run check` (259 tests)
- engine `tsc --noEmit`
- engine ESLint on `LoginServer.ts`