### PR TITLE
Fix lite gateway reconnect killing sessions and stale /status snapshots

### DIFF
--- a/server/gateway/gateway.ts
+++ b/server/gateway/gateway.ts
@@ -287,12 +287,13 @@ const SyncModule = {
     // Helper to complete a bot connection (called immediately or after takeover completes)
     completeBotConnection(ws: any, clientId: string, username: string, preservedState?: BotSession | null, maxMessageLength?: number) {
         const now = Date.now();
+        const preserveFromLive = preservedState?.ws && preservedState.ws.readyState === 1;
         const session: BotSession = {
             ws,
             clientId,
             username,
-            lastState: preservedState?.lastState || null,
-            lastStateReceivedAt: preservedState?.lastStateReceivedAt || 0,
+            lastState: preserveFromLive ? preservedState!.lastState : null,
+            lastStateReceivedAt: preserveFromLive ? preservedState!.lastStateReceivedAt : 0,
             currentActionId: null,
             pendingScreenshotId: null,
             connectedAt: now,
@@ -329,7 +330,9 @@ const SyncModule = {
             }
 
             const existingSession = botSessions.get(username);
-            if (existingSession && existingSession.ws !== ws && existingSession.ws) {
+            const existingWs = existingSession?.ws;
+            const existingWsLive = existingWs && existingWs.readyState === 1; /* OPEN */
+            if (existingSession && existingWs !== ws && existingWsLive) {
                 // Graceful takeover: ask old bot to save and disconnect, WAIT before allowing new session
                 console.log(`[Gateway] Requesting graceful disconnect for existing session: ${existingSession.clientId}`);
                 console.log(`[Gateway] New session ${clientId} will wait for old session to close`);

--- a/server/webclient/src/lite/net/GameConnection.ts
+++ b/server/webclient/src/lite/net/GameConnection.ts
@@ -19,6 +19,8 @@ const DEFAULT_RSA_EXPONENT = '58778699976184461502525193738213253649000149147835
 
 export const LOGIN_RESPONSE: Record<number, string> = {
     3: 'Invalid username or password',
+    // 4 is "disabled" on paper but this server also returns it for login races
+    // (session still tearing down / logged in too fast). Lite retries transiently.
     4: 'Account disabled',
     5: 'Account already logged in',
     6: 'Client out of date (revision or archive CRC mismatch)',

--- a/server/webclient/src/lite/runner.ts
+++ b/server/webclient/src/lite/runner.ts
@@ -12,7 +12,8 @@
 
 import { fileURLToPath } from 'node:url';
 
-import { startSession, type LiteSession } from './session.js';
+import { LoginError } from './net/GameConnection.js';
+import { startSession, type LiteSession, type SessionOptions } from './session.js';
 import { type ActionResult } from '#/bot/ActionExecutor.js';
 import { BotActionQueue, type QueuedBotAction } from '#/bot/ActionQueue.js';
 import type { BotAction, BotWorldState } from '#/bot/types.js';
@@ -27,6 +28,35 @@ import {
 
 const TICK_MS = 20; // matches the browser draw loop that drives BotOverlay.tick()
 const RECONNECT_MS = 3000;
+/** Login codes that often clear after a short wait (session collision / rate limit). */
+const TRANSIENT_LOGIN_CODES = new Set([4, 5, 16]);
+const LOGIN_RETRY_MS = [5_000, 15_000, 30_000];
+const MAX_LOGIN_ATTEMPTS = 3;
+
+async function startSessionWithRetry(opts: SessionOptions): Promise<LiteSession> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt < MAX_LOGIN_ATTEMPTS; attempt++) {
+        try {
+            return await startSession(opts);
+        } catch (err) {
+            lastErr = err;
+            if (!(err instanceof LoginError) || !TRANSIENT_LOGIN_CODES.has(err.code)) {
+                throw err;
+            }
+            if (attempt >= MAX_LOGIN_ATTEMPTS - 1) break;
+            const delay = LOGIN_RETRY_MS[attempt] ?? 30_000;
+            const hint =
+                err.code === 4
+                    ? 'account disabled/busy (often a login race — session may still be active)'
+                    : err.message;
+            console.warn(
+                `[lite-runner] Login rejected (code ${err.code}: ${hint}), retrying in ${delay / 1000}s (${attempt + 1}/${MAX_LOGIN_ATTEMPTS - 1})`
+            );
+            await Bun.sleep(delay);
+        }
+    }
+    throw lastErr;
+}
 
 class LiteGatewayRunner {
     private client: LiteClient;
@@ -44,6 +74,7 @@ class LiteGatewayRunner {
     private lastFastKbdPrayerOffDispatchTick = -1;
 
     private ws: WebSocket | null = null;
+    private readonly gatewayClientId: string;
     private wsConnected = false;
     private preventReconnect = false;
     private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -54,6 +85,8 @@ class LiteGatewayRunner {
         private gatewayUrl: string,
         private fastKbdAttackEnabled = false,
     ) {
+        const { username } = session.client.getCredentials();
+        this.gatewayClientId = `${username}-lite-${Date.now()}`;
         this.client = session.client;
         // State collection and action execution go through the client, which
         // activates this bot's interface table first - see LiteClient.activate.
@@ -86,9 +119,11 @@ class LiteGatewayRunner {
         if (this.ws) return;
 
         console.log(`[lite-runner] Connecting to gateway ${this.gatewayUrl}`);
-        this.ws = new WebSocket(this.gatewayUrl);
+        const socket = new WebSocket(this.gatewayUrl);
+        this.ws = socket;
 
-        this.ws.onopen = () => {
+        socket.onopen = () => {
+            if (socket !== this.ws) return;
             this.wsConnected = true;
             const { username, password } = this.client.getCredentials();
             console.log(`[lite-runner] Gateway connected, registering as '${username}'`);
@@ -96,7 +131,7 @@ class LiteGatewayRunner {
                 type: 'connected',
                 username,
                 password,
-                clientId: `${username}-lite-${Date.now()}`,
+                clientId: this.gatewayClientId,
                 maxMessageLength: this.client.getMaxMessageLength()
             });
             // Drop queued work from the previous connection (BotOverlay.onConnected)
@@ -106,9 +141,13 @@ class LiteGatewayRunner {
                 this.actionQueue.complete(active);
             }
             this.waitTicks = 0;
+            // Publish immediately — don't wait for the next PLAYER_INFO tick. A
+            // zombie gateway snapshot otherwise survives indefinitely.
+            this.sendState();
         };
 
-        this.ws.onmessage = event => {
+        socket.onmessage = event => {
+            if (socket !== this.ws) return;
             try {
                 this.handleMessage(JSON.parse(String(event.data)));
             } catch (e) {
@@ -116,7 +155,8 @@ class LiteGatewayRunner {
             }
         };
 
-        this.ws.onclose = () => {
+        socket.onclose = () => {
+            if (socket !== this.ws) return;
             this.wsConnected = false;
             this.ws = null;
             if (!this.preventReconnect) {
@@ -126,7 +166,7 @@ class LiteGatewayRunner {
             }
         };
 
-        this.ws.onerror = () => {
+        socket.onerror = () => {
             // onclose follows
         };
     }
@@ -371,7 +411,7 @@ const host = env.SERVER || 'localhost';
 // mirror the server's NODE_PROFANITY_FILTER by hand: PROFANITY_FILTER=false in
 // bot.env or the process env disables local chat censoring.
 const profanityRaw = (env.PROFANITY_FILTER ?? process.env.PROFANITY_FILTER ?? '').toLowerCase();
-const session = await startSession({
+const session = await startSessionWithRetry({
     host,
     username: env.BOT_USERNAME!,
     password: env.PASSWORD!,


### PR DESCRIPTION
## Summary

Fixes a fleet-scale bug where a bot could be **live in-game** (e.g. at Yanille) while `/status` and SDK tooling kept reporting **hours-old coords** (e.g. Catherby, tick 6).

Two coupled issues:

1. **Lite runner gateway reconnect self-kill.** Each gateway WS reconnect used a new `clientId`, so the gateway sent `save_and_disconnect` to the previous socket in the **same process**. The old socket handler still called `runner.stop()`, killing the live game session. Fix: stable `clientId` per process, ignore events from superseded sockets, and `sendState()` immediately on gateway connect (not only on PLAYER_INFO ticks).

2. **Gateway zombie bot sessions.** `botSessions` kept dead WebSockets (`readyState !== OPEN`) as "existing sessions" during takeover, preserving `lastStateReceivedAt` from hours ago and dropping new `state` frames because the WS was never registered. Fix: only takeover when the existing socket is OPEN; don't preserve stale timestamps from dead sessions.

Also adds bounded retry (5s / 15s / 30s) for transient login codes 4, 5, 16 — often "logged in too fast" races rather than a real ban.

## Test plan

- [ ] Start lite for a bot, confirm `/status/:bot` `stateAge` drops below 8s within a few seconds of login
- [ ] Kill gateway WS briefly (or restart gateway) and confirm lite reconnect does **not** log out the game client
- [ ] Confirm coords in `/status` match in-game position after moving
- [ ] Rapid `lite-launchd restart` no longer leaves `/status` frozen at pre-crash coords


Made with [Cursor](https://cursor.com)